### PR TITLE
Phase 5: Experimental JupiterWeb timetable import

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -124,6 +124,9 @@ dependencies {
   // Fuel
   implementation(libs.bundles.fuel)
 
+  // OkHttp — used directly for the long-running JupiterWeb timetable import
+  implementation(libs.okhttp)
+
   // SL4J
   implementation(libs.slf4j.simple)
 

--- a/app/src/main/java/app/jopiter/subject/ImportSubjectsDialog.kt
+++ b/app/src/main/java/app/jopiter/subject/ImportSubjectsDialog.kt
@@ -1,0 +1,132 @@
+/*
+* Jopiter App
+* Copyright (C) 2026 Leonardo Colman Lopes
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU Affero General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU Affero General Public License for more details.
+*
+* You should have received a copy of the GNU Affero General Public License
+* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+package app.jopiter.subject
+
+import androidx.compose.foundation.layout.Arrangement.spacedBy
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.AlertDialog
+import androidx.compose.material.LinearProgressIndicator
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.OutlinedTextField
+import androidx.compose.material.Text
+import androidx.compose.material.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalUriHandler
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.unit.dp
+import app.jopiter.R
+import org.koin.androidx.compose.koinViewModel
+
+private const val FEEDBACK_URL = "https://github.com/JopiterApp/JopiterAndroid/issues"
+
+/**
+ * Credential dialog for the experimental JupiterWeb import. Collects the student's USP number and
+ * password, hands them to [ImportViewModel], and closes itself once the import succeeds. Makes the
+ * experimental nature explicit and links to GitHub issues for feedback.
+ */
+@Composable
+fun ImportSubjectsDialog(
+  onDismiss: () -> Unit,
+  viewModel: ImportViewModel = koinViewModel()
+) {
+  val state by viewModel.state.collectAsState()
+  var uspNumber by remember { mutableStateOf("") }
+  var password by remember { mutableStateOf("") }
+  val loading = state is ImportState.Loading
+
+  LaunchedEffect(state) {
+    if (state is ImportState.Success) onDismiss()
+  }
+
+  AlertDialog(
+    onDismissRequest = { if (!loading) onDismiss() },
+    title = { Text(stringResource(R.string.import_subjects_title)) },
+    text = { ImportForm(uspNumber, password, state, { uspNumber = it }, { password = it }) },
+    confirmButton = {
+      TextButton(
+        onClick = { viewModel.import(uspNumber, password) },
+        enabled = !loading,
+        modifier = Modifier.testTag("import_confirm")
+      ) { Text(stringResource(R.string.import_subjects_action)) }
+    },
+    dismissButton = {
+      TextButton(onClick = onDismiss, enabled = !loading) { Text(stringResource(R.string.cancel)) }
+    }
+  )
+}
+
+@Composable
+private fun ImportForm(
+  uspNumber: String,
+  password: String,
+  state: ImportState,
+  onUspNumberChange: (String) -> Unit,
+  onPasswordChange: (String) -> Unit
+) {
+  val uriHandler = LocalUriHandler.current
+  Column(verticalArrangement = spacedBy(8.dp)) {
+    Text(
+      stringResource(R.string.import_subjects_experimental),
+      style = MaterialTheme.typography.body2
+    )
+    TextButton(
+      onClick = { uriHandler.openUri(FEEDBACK_URL) },
+      modifier = Modifier.testTag("import_feedback")
+    ) { Text(stringResource(R.string.import_subjects_feedback)) }
+
+    OutlinedTextField(
+      value = uspNumber,
+      onValueChange = onUspNumberChange,
+      label = { Text(stringResource(R.string.import_subjects_usp_number)) },
+      singleLine = true,
+      keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+      modifier = Modifier.fillMaxWidth().testTag("import_usp_number")
+    )
+    OutlinedTextField(
+      value = password,
+      onValueChange = onPasswordChange,
+      label = { Text(stringResource(R.string.import_subjects_password)) },
+      singleLine = true,
+      visualTransformation = PasswordVisualTransformation(),
+      keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
+      modifier = Modifier.fillMaxWidth().testTag("import_password")
+    )
+
+    when (state) {
+      is ImportState.Loading -> LinearProgressIndicator(Modifier.fillMaxWidth())
+      is ImportState.Error -> Text(
+        stringResource(R.string.import_subjects_error),
+        color = MaterialTheme.colors.error,
+        style = MaterialTheme.typography.caption
+      )
+      else -> Unit
+    }
+  }
+}

--- a/app/src/main/java/app/jopiter/subject/ImportViewModel.kt
+++ b/app/src/main/java/app/jopiter/subject/ImportViewModel.kt
@@ -1,0 +1,81 @@
+/*
+* Jopiter App
+* Copyright (C) 2026 Leonardo Colman Lopes
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU Affero General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU Affero General Public License for more details.
+*
+* You should have received a copy of the GNU Affero General Public License
+* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+package app.jopiter.subject
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import app.jopiter.subject.external.JopiterTimetableClient
+import app.jopiter.subject.repository.SubjectRepository
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import java.time.LocalDate
+
+/** Progress of an experimental JupiterWeb timetable import. */
+sealed interface ImportState {
+  data object Idle : ImportState
+  data object Loading : ImportState
+  data class Success(val importedCount: Int) : ImportState
+  data object Error : ImportState
+}
+
+/**
+ * Drives the experimental JupiterWeb import: posts the student's credentials to
+ * [JopiterTimetableClient], maps the response with [TimetableImporter] and persists the resulting
+ * subjects through [SubjectRepository].
+ *
+ * Credentials are passed straight to the client and never stored on this ViewModel; failures are
+ * collapsed to [ImportState.Error] so nothing derived from them (which could echo the input) leaks.
+ */
+class ImportViewModel(
+  private val client: JopiterTimetableClient,
+  private val subjectRepository: SubjectRepository,
+  private val io: CoroutineDispatcher = Dispatchers.IO,
+  private val today: () -> LocalDate = LocalDate::now
+) : ViewModel() {
+
+  private val _state = MutableStateFlow<ImportState>(ImportState.Idle)
+  val state: StateFlow<ImportState> = _state.asStateFlow()
+
+  fun import(uspNumber: String, password: String) {
+    if (uspNumber.isBlank() || password.isBlank()) {
+      _state.value = ImportState.Error
+      return
+    }
+    _state.value = ImportState.Loading
+    viewModelScope.launch {
+      val result = withContext(io) { client.fetchTimetable(uspNumber, password) }
+      _state.value = result.fold(
+        onSuccess = { timetable ->
+          val subjects = TimetableImporter.toSubjects(timetable, today())
+          withContext(io) { subjects.forEach(subjectRepository::save) }
+          ImportState.Success(subjects.size)
+        },
+        onFailure = { ImportState.Error }
+      )
+    }
+  }
+
+  fun reset() {
+    _state.value = ImportState.Idle
+  }
+}

--- a/app/src/main/java/app/jopiter/subject/SubjectModule.kt
+++ b/app/src/main/java/app/jopiter/subject/SubjectModule.kt
@@ -18,6 +18,7 @@
 package app.jopiter.subject
 
 import app.jopiter.Database
+import app.jopiter.subject.external.JopiterTimetableClient
 import app.jopiter.subject.repository.NoteRepository
 import app.jopiter.subject.repository.PresenceRepository
 import app.jopiter.subject.repository.SubjectRepository
@@ -29,9 +30,11 @@ val subjectModule = module {
   single { SubjectRepository(get<Database>().subjectQueries, get<Database>().classTimeQueries) }
   single { PresenceRepository(get<Database>().presenceQueries) }
   single { NoteRepository(get<Database>().noteQueries) }
+  single { JopiterTimetableClient() }
   viewModel { SubjectsViewModel(get(), get()) }
   viewModel { parameters -> SubjectEditViewModel(get(), parameters.get()) }
   viewModel { parameters -> NotesViewModel(get(), parameters.get()) }
+  viewModel { ImportViewModel(get(), get()) }
 }
 
 /** Convenience for screens to obtain a [SubjectEditViewModel] bound to a subject id. */

--- a/app/src/main/java/app/jopiter/subject/SubjectsPage.kt
+++ b/app/src/main/java/app/jopiter/subject/SubjectsPage.kt
@@ -38,9 +38,13 @@ import androidx.compose.material.Text
 import androidx.compose.material.TextButton
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.CloudDownload
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
@@ -59,11 +63,22 @@ fun SubjectsPage(
   viewModel: SubjectsViewModel = koinViewModel()
 ) {
   val summaries by viewModel.summaries.collectAsState()
+  var showImport by remember { mutableStateOf(false) }
+
+  if (showImport) ImportSubjectsDialog(onDismiss = { showImport = false })
 
   Scaffold(
     floatingActionButton = {
-      FloatingActionButton(onClick = onAddSubject, modifier = Modifier.testTag("add_subject_fab")) {
-        Icon(Icons.Default.Add, contentDescription = stringResource(R.string.add_subject))
+      Column(horizontalAlignment = Alignment.End, verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        FloatingActionButton(
+          onClick = { showImport = true },
+          modifier = Modifier.testTag("import_fab")
+        ) {
+          Icon(Icons.Default.CloudDownload, contentDescription = stringResource(R.string.import_subjects))
+        }
+        FloatingActionButton(onClick = onAddSubject, modifier = Modifier.testTag("add_subject_fab")) {
+          Icon(Icons.Default.Add, contentDescription = stringResource(R.string.add_subject))
+        }
       }
     }
   ) { padding ->

--- a/app/src/main/java/app/jopiter/subject/TimetableImporter.kt
+++ b/app/src/main/java/app/jopiter/subject/TimetableImporter.kt
@@ -1,0 +1,61 @@
+/*
+* Jopiter App
+* Copyright (C) 2026 Leonardo Colman Lopes
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU Affero General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU Affero General Public License for more details.
+*
+* You should have received a copy of the GNU Affero General Public License
+* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+package app.jopiter.subject
+
+import app.jopiter.subject.external.TimetableEntry
+import app.jopiter.subject.model.ClassTime
+import app.jopiter.subject.model.Subject
+import java.time.DayOfWeek
+import java.time.LocalDate
+import java.time.LocalTime
+import java.time.format.DateTimeFormatter
+
+private val TimetableTimeFormat: DateTimeFormatter = DateTimeFormatter.ofPattern("HH:mm:ss")
+
+/**
+ * Pure mapping from a JupiterWeb timetable response into persistable [Subject]s.
+ *
+ * A subject taught on several weekdays arrives as one [TimetableEntry] per day; entries are grouped
+ * by subject code (falling back to its name) so each becomes a single [Subject] holding every weekly
+ * [ClassTime]. Class times are sorted by day then start time for a stable display order.
+ */
+object TimetableImporter {
+
+  fun toSubjects(
+    timetable: Map<DayOfWeek, List<TimetableEntry>>,
+    creationDate: LocalDate = LocalDate.now()
+  ): List<Subject> {
+    val bySubject = timetable.entries
+      .flatMap { (day, entries) -> entries.map { day to it } }
+      .groupBy { (_, entry) -> entry.subject.code.ifBlank { entry.information.name } }
+
+    return bySubject.map { (key, dayEntries) ->
+      val sample = dayEntries.first().second
+      Subject(
+        name = sample.information.name.ifBlank { key },
+        code = sample.subject.code,
+        creationDate = creationDate,
+        classTimes = dayEntries
+          .map { (day, entry) -> ClassTime(day, parse(entry.subject.startTime), parse(entry.subject.endTime)) }
+          .sortedWith(compareBy({ it.dayOfWeek }, { it.startAt }))
+      )
+    }
+  }
+
+  private fun parse(time: String): LocalTime = LocalTime.parse(time, TimetableTimeFormat)
+}

--- a/app/src/main/java/app/jopiter/subject/external/JopiterTimetableClient.kt
+++ b/app/src/main/java/app/jopiter/subject/external/JopiterTimetableClient.kt
@@ -1,0 +1,79 @@
+/*
+* Jopiter App
+* Copyright (C) 2026 Leonardo Colman Lopes
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU Affero General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU Affero General Public License for more details.
+*
+* You should have received a copy of the GNU Affero General Public License
+* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+package app.jopiter.subject.external
+
+import com.fasterxml.jackson.core.type.TypeReference
+import com.fasterxml.jackson.databind.DeserializationFeature
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import java.time.DayOfWeek
+import java.time.Duration
+
+private const val DEFAULT_TIMETABLE_URL = "https://timetable-fetcher-dot-jopiter-225101.appspot.com/timetable"
+private const val TIMEOUT_SECONDS = 200L
+private val JSON_MEDIA_TYPE = "application/json".toMediaType()
+private val TIMETABLE_TYPE = object : TypeReference<Map<DayOfWeek, List<TimetableEntry>>>() {}
+
+/**
+ * Fetches the student's weekly timetable from JupiterWeb through the timetable-fetcher backend.
+ *
+ * The backend logs into JupiterWeb on the student's behalf and scrapes their enrolled classes, which
+ * can take well over a minute — hence the long [TIMEOUT_SECONDS] timeout (OkHttp's 10s default would
+ * never suffice). This is an experimental, best-effort integration: USP can change JupiterWeb at any
+ * time and break it.
+ *
+ * Security: [uspNumber] and [password] are sent only as the JSON body of the HTTPS request to
+ * [timetableUrl]; they are never persisted nor logged (failures are surfaced as opaque errors).
+ */
+open class JopiterTimetableClient(
+  private val timetableUrl: String = DEFAULT_TIMETABLE_URL,
+  private val objectMapper: ObjectMapper = lenientMapper(),
+  private val httpClient: OkHttpClient = longTimeoutClient()
+) {
+
+  open fun fetchTimetable(uspNumber: String, password: String): Result<Map<DayOfWeek, List<TimetableEntry>>> =
+    runCatching {
+      val body = objectMapper.writeValueAsString(mapOf("user" to uspNumber, "pass" to password))
+      val request = Request.Builder()
+        .url(timetableUrl)
+        .post(body.toRequestBody(JSON_MEDIA_TYPE))
+        .build()
+
+      httpClient.newCall(request).execute().use { response ->
+        check(response.isSuccessful) { "Timetable request failed with status ${response.code}" }
+        objectMapper.readValue(response.body.string(), TIMETABLE_TYPE)
+      }
+    }
+}
+
+private fun lenientMapper(): ObjectMapper =
+  jacksonObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+
+private fun longTimeoutClient(): OkHttpClient {
+  val timeout = Duration.ofSeconds(TIMEOUT_SECONDS)
+  return OkHttpClient.Builder()
+    .connectTimeout(timeout)
+    .readTimeout(timeout)
+    .writeTimeout(timeout)
+    .callTimeout(timeout)
+    .build()
+}

--- a/app/src/main/java/app/jopiter/subject/external/TimetableDtos.kt
+++ b/app/src/main/java/app/jopiter/subject/external/TimetableDtos.kt
@@ -1,0 +1,46 @@
+/*
+* Jopiter App
+* Copyright (C) 2026 Leonardo Colman Lopes
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU Affero General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU Affero General Public License for more details.
+*
+* You should have received a copy of the GNU Affero General Public License
+* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+package app.jopiter.subject.external
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+
+/**
+ * Wire shape of one class in a JupiterWeb timetable, as returned by the timetable-fetcher backend.
+ * The endpoint keys these entries by [java.time.DayOfWeek] name (e.g. `"MONDAY"`). Times are raw
+ * `HH:mm:ss` strings here and parsed by [app.jopiter.subject.TimetableImporter].
+ *
+ * Defaults plus lenient deserialization make parsing resilient to an experimental, unversioned API.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class TimetableEntry(
+  val subject: TimetableSubject = TimetableSubject(),
+  val information: TimetableInformation = TimetableInformation()
+)
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class TimetableSubject(
+  val code: String = "",
+  val classCode: String = "",
+  val startTime: String = "",
+  val endTime: String = ""
+)
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class TimetableInformation(
+  val name: String = ""
+)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -73,4 +73,14 @@
     <string name="class_time_start">Início</string>
     <string name="class_time_end">Fim</string>
     <string name="class_time_summary">%1$s, %2$s–%3$s</string>
+
+    <!-- JupiterWeb import -->
+    <string name="import_subjects">Importar do JupiterWeb</string>
+    <string name="import_subjects_title">Importar do JupiterWeb</string>
+    <string name="import_subjects_action">Importar</string>
+    <string name="import_subjects_experimental">Recurso experimental: usamos suas credenciais USP apenas para buscar suas disciplinas no JupiterWeb. Elas são enviadas com segurança ao servidor e nunca são salvas. Pode falhar — o JupiterWeb muda com frequência.</string>
+    <string name="import_subjects_feedback">Enviar feedback no GitHub</string>
+    <string name="import_subjects_usp_number">Número USP</string>
+    <string name="import_subjects_password">Senha USP</string>
+    <string name="import_subjects_error">Não foi possível importar. Verifique suas credenciais e tente novamente.</string>
 </resources>

--- a/app/src/test/java/app/jopiter/subject/ImportViewModelTest.kt
+++ b/app/src/test/java/app/jopiter/subject/ImportViewModelTest.kt
@@ -1,0 +1,107 @@
+/*
+* Jopiter App
+* Copyright (C) 2026 Leonardo Colman Lopes
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU Affero General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU Affero General Public License for more details.
+*
+* You should have received a copy of the GNU Affero General Public License
+* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+package app.jopiter.subject
+
+import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver
+import app.jopiter.Database
+import app.jopiter.subject.external.JopiterTimetableClient
+import app.jopiter.subject.external.TimetableEntry
+import app.jopiter.subject.external.TimetableInformation
+import app.jopiter.subject.external.TimetableSubject
+import app.jopiter.subject.repository.SubjectRepository
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import java.time.DayOfWeek
+import java.time.DayOfWeek.MONDAY
+import java.time.LocalDate
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ImportViewModelTest : FunSpec({
+
+  beforeTest { Dispatchers.setMain(UnconfinedTestDispatcher()) }
+  afterTest { Dispatchers.resetMain() }
+
+  fun repository(): SubjectRepository {
+    val driver = JdbcSqliteDriver(JdbcSqliteDriver.IN_MEMORY)
+    Database.Schema.create(driver)
+    val database = Database(driver)
+    return SubjectRepository(database.subjectQueries, database.classTimeQueries)
+  }
+
+  class FakeClient(
+    private val result: Result<Map<DayOfWeek, List<TimetableEntry>>>
+  ) : JopiterTimetableClient() {
+    var calls = 0
+      private set
+
+    override fun fetchTimetable(uspNumber: String, password: String): Result<Map<DayOfWeek, List<TimetableEntry>>> {
+      calls++
+      return result
+    }
+  }
+
+  val sampleTimetable = mapOf(
+    MONDAY to listOf(
+      TimetableEntry(
+        TimetableSubject("MAC0110", "T1", "08:00:00", "09:40:00"),
+        TimetableInformation("Introdução à Computação")
+      )
+    )
+  )
+
+  fun viewModel(client: JopiterTimetableClient, repository: SubjectRepository) =
+    ImportViewModel(client, repository, UnconfinedTestDispatcher(), today = { LocalDate.of(2026, 3, 1) })
+
+  test("imports and persists subjects on success") {
+    val repository = repository()
+    val viewModel = viewModel(FakeClient(Result.success(sampleTimetable)), repository)
+
+    viewModel.import("12345678", "secret")
+
+    viewModel.state.value shouldBe ImportState.Success(1)
+    repository.subjects.first().single().name shouldBe "Introdução à Computação"
+  }
+
+  test("reports an error and persists nothing on client failure") {
+    val repository = repository()
+    val viewModel = viewModel(FakeClient(Result.failure(RuntimeException("boom"))), repository)
+
+    viewModel.import("12345678", "secret")
+
+    viewModel.state.value.shouldBeInstanceOf<ImportState.Error>()
+    repository.subjects.first().shouldBeEmpty()
+  }
+
+  test("rejects blank credentials without calling the client") {
+    val client = FakeClient(Result.success(sampleTimetable))
+    val viewModel = viewModel(client, repository())
+
+    viewModel.import("  ", "")
+
+    viewModel.state.value.shouldBeInstanceOf<ImportState.Error>()
+    client.calls shouldBe 0
+  }
+})

--- a/app/src/test/java/app/jopiter/subject/TimetableImporterTest.kt
+++ b/app/src/test/java/app/jopiter/subject/TimetableImporterTest.kt
@@ -1,0 +1,89 @@
+/*
+* Jopiter App
+* Copyright (C) 2026 Leonardo Colman Lopes
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU Affero General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU Affero General Public License for more details.
+*
+* You should have received a copy of the GNU Affero General Public License
+* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+package app.jopiter.subject
+
+import app.jopiter.subject.external.TimetableEntry
+import app.jopiter.subject.external.TimetableInformation
+import app.jopiter.subject.external.TimetableSubject
+import app.jopiter.subject.model.ClassTime
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.shouldBe
+import java.time.DayOfWeek.MONDAY
+import java.time.DayOfWeek.WEDNESDAY
+import java.time.LocalDate
+import java.time.LocalTime
+
+class TimetableImporterTest : FunSpec({
+
+  fun entry(code: String, name: String, start: String, end: String) =
+    TimetableEntry(TimetableSubject(code, "$code-T1", start, end), TimetableInformation(name))
+
+  test("empty timetable yields no subjects") {
+    TimetableImporter.toSubjects(emptyMap()).shouldBeEmpty()
+  }
+
+  test("maps a single class into a subject with one class time") {
+    val timetable = mapOf(MONDAY to listOf(entry("MAC0110", "Introdução à Computação", "08:00:00", "09:40:00")))
+
+    val subject = TimetableImporter.toSubjects(timetable, LocalDate.of(2026, 3, 1)).single()
+
+    subject.name shouldBe "Introdução à Computação"
+    subject.code shouldBe "MAC0110"
+    subject.creationDate shouldBe LocalDate.of(2026, 3, 1)
+    subject.classTimes.shouldContainExactly(
+      ClassTime(MONDAY, LocalTime.of(8, 0), LocalTime.of(9, 40))
+    )
+  }
+
+  test("merges the same subject taught on several days into one subject, sorted by day then time") {
+    val timetable = mapOf(
+      WEDNESDAY to listOf(entry("MAC0110", "Introdução à Computação", "10:00:00", "11:40:00")),
+      MONDAY to listOf(entry("MAC0110", "Introdução à Computação", "08:00:00", "09:40:00"))
+    )
+
+    val subject = TimetableImporter.toSubjects(timetable).single()
+
+    subject.code shouldBe "MAC0110"
+    subject.classTimes.shouldContainExactly(
+      ClassTime(MONDAY, LocalTime.of(8, 0), LocalTime.of(9, 40)),
+      ClassTime(WEDNESDAY, LocalTime.of(10, 0), LocalTime.of(11, 40))
+    )
+  }
+
+  test("keeps distinct subject codes apart") {
+    val timetable = mapOf(
+      MONDAY to listOf(
+        entry("MAC0110", "Introdução à Computação", "08:00:00", "09:40:00"),
+        entry("MAT0112", "Vetores e Geometria", "10:00:00", "11:40:00")
+      )
+    )
+
+    TimetableImporter.toSubjects(timetable).map { it.code } shouldContainExactly listOf("MAC0110", "MAT0112")
+  }
+
+  test("falls back to the name when a class has no code") {
+    val timetable = mapOf(MONDAY to listOf(entry("", "Optativa Livre", "19:00:00", "20:40:00")))
+
+    val subject = TimetableImporter.toSubjects(timetable).single()
+
+    subject.name shouldBe "Optativa Livre"
+    subject.code shouldBe ""
+  }
+})

--- a/app/src/test/java/app/jopiter/subject/external/JopiterTimetableClientTest.kt
+++ b/app/src/test/java/app/jopiter/subject/external/JopiterTimetableClientTest.kt
@@ -1,0 +1,93 @@
+/*
+* Jopiter App
+* Copyright (C) 2026 Leonardo Colman Lopes
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU Affero General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU Affero General Public License for more details.
+*
+* You should have received a copy of the GNU Affero General Public License
+* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+package app.jopiter.subject.external
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.extensions.mockserver.MockServerListener
+import io.kotest.matchers.result.shouldBeFailure
+import io.kotest.matchers.result.shouldBeSuccess
+import io.kotest.matchers.shouldBe
+import org.mockserver.client.MockServerClient
+import org.mockserver.matchers.MatchType.ONLY_MATCHING_FIELDS
+import org.mockserver.model.HttpError.error
+import org.mockserver.model.HttpRequest.request
+import org.mockserver.model.HttpResponse.response
+import org.mockserver.model.JsonBody.json
+import org.mockserver.verify.VerificationTimes.exactly
+import java.time.DayOfWeek.MONDAY
+import java.time.DayOfWeek.WEDNESDAY
+
+private val SAMPLE_TIMETABLE = """
+  {
+    "MONDAY": [
+      {
+        "subject": { "code": "MAC0110", "classCode": "2026100", "startTime": "08:00:00", "endTime": "09:40:00" },
+        "information": { "name": "Introdução à Computação" }
+      }
+    ],
+    "WEDNESDAY": [
+      {
+        "subject": { "code": "MAC0110", "classCode": "2026100", "startTime": "10:00:00", "endTime": "11:40:00" },
+        "information": { "name": "Introdução à Computação" }
+      }
+    ]
+  }
+""".trimIndent()
+
+class JopiterTimetableClientTest : FunSpec({
+
+  val mockServerListener = listener(MockServerListener())
+  val mockServer by lazy { mockServerListener.mockServer!! }
+  val target by lazy { JopiterTimetableClient("http://localhost:${mockServer.port}/timetable") }
+
+  test("returns failure when the connection is dropped") {
+    mockServer.`when`(request()).error(error().withDropConnection(true))
+
+    target.fetchTimetable("12345678", "secret").shouldBeFailure()
+  }
+
+  test("parses the timetable returned by the backend") {
+    mockServer.respondWith(SAMPLE_TIMETABLE)
+
+    val result = target.fetchTimetable("12345678", "secret")
+
+    result.shouldBeSuccess { timetable ->
+      timetable.keys shouldBe setOf(MONDAY, WEDNESDAY)
+      timetable.getValue(MONDAY).single().subject.code shouldBe "MAC0110"
+      timetable.getValue(MONDAY).single().information.name shouldBe "Introdução à Computação"
+      timetable.getValue(WEDNESDAY).single().subject.startTime shouldBe "10:00:00"
+    }
+  }
+
+  test("sends the credentials only as the POST body of the timetable request") {
+    mockServer.respondWith(SAMPLE_TIMETABLE)
+
+    target.fetchTimetable("12345678", "secret").shouldBeSuccess()
+
+    mockServer.verify(
+      request()
+        .withMethod("POST")
+        .withPath("/timetable")
+        .withBody(json("""{ "user": "12345678", "pass": "secret" }""", ONLY_MATCHING_FIELDS)),
+      exactly(1)
+    )
+  }
+})
+
+private fun MockServerClient.respondWith(body: String) =
+  `when`(request().withMethod("POST")).respond(response().withBody(json(body)))

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,6 @@
 [versions]
 fuel = "3.0.0-alpha1"
+okhttp = "5.0.0-alpha.10"
 sqlDelight = "2.0.1"
 android-gradle = "8.0.2"
 kotlin = "1.9.20"
@@ -14,6 +15,7 @@ coroutines = "1.7.3"
 android-gradle = { module = "com.android.tools.build:gradle", version.ref = "android-gradle" }
 fuel = { module = "com.github.kittinunf.fuel:fuel", version.ref = "fuel" }
 fuel-jackson-jvm = { module = "com.github.kittinunf.fuel:fuel-jackson-jvm", version.ref = "fuel" }
+okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }
 kotlin-gradle-plugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
 sqldelight-android-driver = { module = "app.cash.sqldelight:android-driver", version.ref = "sqlDelight" }
 sqdelight-sqlite-driver = { module = "app.cash.sqldelight:sqlite-driver", version.ref = "sqlDelight" }


### PR DESCRIPTION
## What

Brings the legacy **JupiterWeb import** into the modern app: students can pull their enrolled subjects (with weekly class times) straight from JupiterWeb instead of typing each one by hand.

> ⚠️ **Experimental** — this scrapes JupiterWeb through the timetable-fetcher backend, which USP can change at any time. There's **no guarantee it works**, and the dialog says so. Feedback welcome on the [issue tracker](https://github.com/JopiterApp/JopiterAndroid/issues).

## How

- **`JopiterTimetableClient`** — POSTs the USP number + password as a JSON body to `https://timetable-fetcher-dot-jopiter-225101.appspot.com/timetable` over HTTPS. Uses OkHttp directly with a **200s timeout** (the backend logs into JupiterWeb and scrapes, so OkHttp's 10s default never suffices).
- **`TimetableImporter`** — pure mapping of `Map<DayOfWeek, List<TimetableEntry>>` into persistable `Subject`s, merging a subject taught on several weekdays into one `Subject` with multiple `ClassTime`s.
- **`ImportViewModel` + `ImportSubjectsDialog`** — credential dialog launched from a second FAB on the Subjects screen; explicit experimental warning + GitHub-feedback link; loading / error states.
- Registered `JopiterTimetableClient` + `ImportViewModel` in `subjectModule`.

## Security

Credentials are sent **only** as the JSON body of the HTTPS request — **never persisted, never logged**. Import failures collapse to an opaque `ImportState.Error` so nothing derived from credentials can leak.

## Schema

**No schema change** — reuses the existing `Subject` / `ClassTime` tables via `SubjectRepository`, so no migration is needed.

## Tests

- `TimetableImporterTest` — merge-by-code across days, distinct codes, time parsing, name/code fallback.
- `JopiterTimetableClientTest` (MockServer) — parses backend payload, sends credentials as the POST body, fails on dropped connection.
- `ImportViewModelTest` — success persists subjects, client failure → error (persists nothing), blank credentials rejected without calling the client.

## Validation

- `:app:testUnofficialDebugUnitTest`, `:app:detekt`, `:app:spotlessCheck`, `:app:assembleUnofficialDebug` all green (JDK 17).
- Emulator (Pixel, API 36): import FAB → dialog with experimental copy + feedback link + USP fields; blank submit shows the error message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)