### PR TITLE
Phase 6: Presence & appointment reminder notifications (WorkManager)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -127,6 +127,9 @@ dependencies {
   // OkHttp — used directly for the long-running JupiterWeb timetable import
   implementation(libs.okhttp)
 
+  // WorkManager — schedules presence/appointment reminder notifications
+  implementation(libs.work.runtime)
+
   // SL4J
   implementation(libs.slf4j.simple)
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
           xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
     <application
             android:name=".JopiterApplication"

--- a/app/src/main/java/app/jopiter/JopiterApplication.kt
+++ b/app/src/main/java/app/jopiter/JopiterApplication.kt
@@ -20,6 +20,9 @@ package app.jopiter
 import android.app.Application
 import app.cash.sqldelight.driver.android.AndroidSqliteDriver
 import app.jopiter.calendar.calendarModule
+import app.jopiter.notification.ReminderCoordinator
+import app.jopiter.notification.ReminderNotifications
+import app.jopiter.notification.notificationModule
 import app.jopiter.restaurant.restaurantModule
 import app.jopiter.subject.subjectModule
 import org.koin.android.ext.koin.androidContext
@@ -31,19 +34,19 @@ class JopiterApplication : Application() {
 
   override fun onCreate() {
     super.onCreate()
-    startKoin()
-  }
-
-  private fun startKoin() {
-    startKoin {
+    val koin = startKoin {
       androidLogger()
       androidContext(this@JopiterApplication)
       modules(restaurantModule)
       modules(subjectModule)
       modules(calendarModule)
+      modules(notificationModule)
       modules(module {
         single { Database(AndroidSqliteDriver(Database.Schema, get(), "Database")) }
       })
-    }
+    }.koin
+
+    ReminderNotifications.createChannels(this)
+    koin.get<ReminderCoordinator>().start()
   }
 }

--- a/app/src/main/java/app/jopiter/MainActivity.kt
+++ b/app/src/main/java/app/jopiter/MainActivity.kt
@@ -17,15 +17,20 @@
 */
 package app.jopiter
 
+import android.Manifest
+import android.os.Build
 import android.os.Bundle
 import androidx.activity.ComponentActivity
+import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.compose.setContent
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.DrawerValue
 import androidx.compose.material.Scaffold
 import androidx.compose.material.rememberDrawerState
 import androidx.compose.material.rememberScaffoldState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
@@ -49,6 +54,8 @@ class MainActivity : ComponentActivity() {
 
 @Composable
 private fun MainScreen() {
+  RequestNotificationPermission()
+
   val coroutineScope = rememberCoroutineScope()
   val drawerState = rememberDrawerState(DrawerValue.Closed)
   val navController = rememberNavController()
@@ -76,4 +83,12 @@ private fun MainScreen() {
   ) { padding ->
     JopiterNavHost(navController, Modifier.padding(padding))
   }
+}
+
+/** Asks for the notification permission once on launch (Android 13+); a no-op on older versions. */
+@Composable
+private fun RequestNotificationPermission() {
+  if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) return
+  val launcher = rememberLauncherForActivityResult(ActivityResultContracts.RequestPermission()) {}
+  LaunchedEffect(Unit) { launcher.launch(Manifest.permission.POST_NOTIFICATIONS) }
 }

--- a/app/src/main/java/app/jopiter/notification/AppointmentReminderScheduler.kt
+++ b/app/src/main/java/app/jopiter/notification/AppointmentReminderScheduler.kt
@@ -1,0 +1,50 @@
+/*
+* Jopiter App
+* Copyright (C) 2026 Leonardo Colman Lopes
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU Affero General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU Affero General Public License for more details.
+*
+* You should have received a copy of the GNU Affero General Public License
+* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+@file:Suppress("MagicNumber")
+
+package app.jopiter.notification
+
+import app.jopiter.calendar.model.Appointment
+import java.time.LocalDateTime
+
+/**
+ * Pure scheduling logic for appointment reminders. Mirrors the legacy behaviour: warn 30, 15 and
+ * 7-down-to-1 days before the appointment (at the same time of day), plus a same-day nudge 12 hours
+ * before it. Only reminders still in the future (relative to [now]) are produced. No Android deps.
+ */
+object AppointmentReminderScheduler {
+
+  private val DAY_OFFSETS = listOf(30, 15, 7, 6, 5, 4, 3, 2, 1)
+  private const val SAME_DAY_HOURS_BEFORE = 12L
+  const val SAME_DAY = 0
+
+  fun remindersFor(
+    appointment: Appointment,
+    now: LocalDateTime,
+    subjectName: String? = null
+  ): List<AppointmentReminder> {
+    val triggers = DAY_OFFSETS.map { days -> days to appointment.dateTime.minusDays(days.toLong()) } +
+      (SAME_DAY to appointment.dateTime.minusHours(SAME_DAY_HOURS_BEFORE))
+
+    return triggers
+      .filter { (_, triggerAt) -> triggerAt.isAfter(now) }
+      .map { (daysLeft, triggerAt) ->
+        AppointmentReminder(appointment.id, appointment.name, subjectName, daysLeft, triggerAt)
+      }
+  }
+}

--- a/app/src/main/java/app/jopiter/notification/AppointmentReminderWorker.kt
+++ b/app/src/main/java/app/jopiter/notification/AppointmentReminderWorker.kt
@@ -1,0 +1,51 @@
+/*
+* Jopiter App
+* Copyright (C) 2026 Leonardo Colman Lopes
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU Affero General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU Affero General Public License for more details.
+*
+* You should have received a copy of the GNU Affero General Public License
+* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+package app.jopiter.notification
+
+import android.content.Context
+import androidx.work.CoroutineWorker
+import androidx.work.WorkerParameters
+import java.time.LocalDateTime
+
+/**
+ * Posts a single appointment reminder ("N days left"). One-shot: each of an appointment's reminders
+ * is enqueued as its own worker. All data comes from [inputData].
+ */
+class AppointmentReminderWorker(context: Context, params: WorkerParameters) : CoroutineWorker(context, params) {
+
+  override suspend fun doWork(): Result {
+    val reminder = AppointmentReminder(
+      appointmentId = inputData.getLong(KEY_APPOINTMENT_ID, 0),
+      appointmentName = inputData.getString(KEY_APPOINTMENT_NAME).orEmpty(),
+      subjectName = inputData.getString(KEY_SUBJECT_NAME),
+      daysLeft = inputData.getInt(KEY_DAYS_LEFT, 0),
+      triggerAt = LocalDateTime.now()
+    )
+
+    ReminderNotifications.notifyAppointment(applicationContext, reminder)
+
+    return Result.success()
+  }
+
+  companion object {
+    const val KEY_APPOINTMENT_ID = "appointment_id"
+    const val KEY_APPOINTMENT_NAME = "appointment_name"
+    const val KEY_SUBJECT_NAME = "subject_name"
+    const val KEY_DAYS_LEFT = "days_left"
+  }
+}

--- a/app/src/main/java/app/jopiter/notification/NotificationModule.kt
+++ b/app/src/main/java/app/jopiter/notification/NotificationModule.kt
@@ -1,0 +1,29 @@
+/*
+* Jopiter App
+* Copyright (C) 2026 Leonardo Colman Lopes
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU Affero General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU Affero General Public License for more details.
+*
+* You should have received a copy of the GNU Affero General Public License
+* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+package app.jopiter.notification
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import org.koin.android.ext.koin.androidContext
+import org.koin.dsl.module
+
+val notificationModule = module {
+  single { ReminderScheduler(androidContext()) }
+  single { ReminderCoordinator(get(), get(), get(), CoroutineScope(SupervisorJob() + Dispatchers.Default)) }
+}

--- a/app/src/main/java/app/jopiter/notification/PresenceReminderScheduler.kt
+++ b/app/src/main/java/app/jopiter/notification/PresenceReminderScheduler.kt
@@ -1,0 +1,49 @@
+/*
+* Jopiter App
+* Copyright (C) 2026 Leonardo Colman Lopes
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU Affero General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU Affero General Public License for more details.
+*
+* You should have received a copy of the GNU Affero General Public License
+* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+package app.jopiter.notification
+
+import app.jopiter.subject.model.Subject
+import java.time.DayOfWeek
+import java.time.LocalDateTime
+import java.time.LocalTime
+import java.time.temporal.TemporalAdjusters.nextOrSame
+
+/**
+ * Pure scheduling logic for presence reminders: one reminder per weekly class, due the next time
+ * that class starts. Reused both for the initial scheduling and for the weekly reschedule a worker
+ * performs after it fires. No Android dependencies, so it is fully unit-testable.
+ */
+object PresenceReminderScheduler {
+
+  fun remindersFor(subject: Subject, now: LocalDateTime): List<PresenceReminder> =
+    subject.classTimes.map { classTime ->
+      PresenceReminder(
+        subjectId = subject.id,
+        subjectName = subject.name,
+        dayOfWeek = classTime.dayOfWeek,
+        startAt = classTime.startAt,
+        triggerAt = nextOccurrence(classTime.dayOfWeek, classTime.startAt, now)
+      )
+    }
+
+  /** The next date-time a class on [dayOfWeek] at [startAt] starts, strictly after [now]. */
+  fun nextOccurrence(dayOfWeek: DayOfWeek, startAt: LocalTime, now: LocalDateTime): LocalDateTime {
+    val candidate = now.toLocalDate().with(nextOrSame(dayOfWeek)).atTime(startAt)
+    return if (candidate.isAfter(now)) candidate else candidate.plusWeeks(1)
+  }
+}

--- a/app/src/main/java/app/jopiter/notification/PresenceReminderWorker.kt
+++ b/app/src/main/java/app/jopiter/notification/PresenceReminderWorker.kt
@@ -1,0 +1,58 @@
+/*
+* Jopiter App
+* Copyright (C) 2026 Leonardo Colman Lopes
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU Affero General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU Affero General Public License for more details.
+*
+* You should have received a copy of the GNU Affero General Public License
+* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+package app.jopiter.notification
+
+import android.content.Context
+import androidx.work.CoroutineWorker
+import androidx.work.WorkerParameters
+import java.time.DayOfWeek
+import java.time.LocalDateTime
+import java.time.LocalTime
+
+/**
+ * Posts a presence reminder when a class starts, then re-enqueues itself for the same class next
+ * week so the reminder recurs even if the app is never reopened. All data comes from [inputData];
+ * the worker touches no repository.
+ */
+class PresenceReminderWorker(context: Context, params: WorkerParameters) : CoroutineWorker(context, params) {
+
+  override suspend fun doWork(): Result {
+    val startAt = inputData.getString(KEY_START_AT)?.let(LocalTime::parse) ?: return Result.failure()
+    val reminder = PresenceReminder(
+      subjectId = inputData.getLong(KEY_SUBJECT_ID, 0),
+      subjectName = inputData.getString(KEY_SUBJECT_NAME).orEmpty(),
+      dayOfWeek = DayOfWeek.of(inputData.getInt(KEY_DAY_OF_WEEK, DayOfWeek.MONDAY.value)),
+      startAt = startAt,
+      triggerAt = LocalDateTime.now()
+    )
+
+    ReminderNotifications.notifyPresence(applicationContext, reminder)
+
+    val next = PresenceReminderScheduler.nextOccurrence(reminder.dayOfWeek, reminder.startAt, LocalDateTime.now())
+    ReminderScheduler(applicationContext).enqueuePresence(reminder.copy(triggerAt = next))
+
+    return Result.success()
+  }
+
+  companion object {
+    const val KEY_SUBJECT_ID = "subject_id"
+    const val KEY_SUBJECT_NAME = "subject_name"
+    const val KEY_DAY_OF_WEEK = "day_of_week"
+    const val KEY_START_AT = "start_at"
+  }
+}

--- a/app/src/main/java/app/jopiter/notification/ReminderCoordinator.kt
+++ b/app/src/main/java/app/jopiter/notification/ReminderCoordinator.kt
@@ -1,0 +1,46 @@
+/*
+* Jopiter App
+* Copyright (C) 2026 Leonardo Colman Lopes
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU Affero General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU Affero General Public License for more details.
+*
+* You should have received a copy of the GNU Affero General Public License
+* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+package app.jopiter.notification
+
+import app.jopiter.calendar.repository.AppointmentRepository
+import app.jopiter.subject.repository.SubjectRepository
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.launch
+
+/**
+ * Keeps scheduled reminders in sync with the data. Observes the subject and appointment flows and
+ * re-schedules through [ReminderScheduler] whenever anything changes — so creating, editing or
+ * deleting a subject/appointment transparently (re)schedules its notifications.
+ */
+class ReminderCoordinator(
+  private val scheduler: ReminderScheduler,
+  private val subjectRepository: SubjectRepository,
+  private val appointmentRepository: AppointmentRepository,
+  private val scope: CoroutineScope
+) {
+
+  fun start() {
+    scope.launch { subjectRepository.subjects.collect(scheduler::syncPresence) }
+    scope.launch {
+      combine(appointmentRepository.appointments, subjectRepository.subjects) { appointments, subjects ->
+        appointments to subjects.associate { it.id to it.name }
+      }.collect { (appointments, subjectNames) -> scheduler.syncAppointments(appointments, subjectNames) }
+    }
+  }
+}

--- a/app/src/main/java/app/jopiter/notification/ReminderNotifications.kt
+++ b/app/src/main/java/app/jopiter/notification/ReminderNotifications.kt
@@ -1,0 +1,129 @@
+/*
+* Jopiter App
+* Copyright (C) 2026 Leonardo Colman Lopes
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU Affero General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU Affero General Public License for more details.
+*
+* You should have received a copy of the GNU Affero General Public License
+* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+package app.jopiter.notification
+
+import android.Manifest.permission.POST_NOTIFICATIONS
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.NotificationManager.IMPORTANCE_DEFAULT
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageManager.PERMISSION_GRANTED
+import android.os.Build
+import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
+import androidx.core.content.ContextCompat
+import app.jopiter.MainActivity
+import app.jopiter.R
+import app.jopiter.common.TimeFormat
+
+/**
+ * Creates the notification channels and posts presence/appointment reminders. Posting is guarded by
+ * the runtime [POST_NOTIFICATIONS] permission so it is a silent no-op when the user declined it.
+ */
+object ReminderNotifications {
+
+  const val PRESENCE_CHANNEL_ID = "presence_reminders"
+  const val APPOINTMENT_CHANNEL_ID = "appointment_reminders"
+
+  fun createChannels(context: Context) {
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return
+    val manager = context.getSystemService(NotificationManager::class.java) ?: return
+    manager.createNotificationChannel(
+      channel(context, PRESENCE_CHANNEL_ID, R.string.presence_channel_name, R.string.presence_channel_description)
+    )
+    manager.createNotificationChannel(
+      channel(
+        context,
+        APPOINTMENT_CHANNEL_ID,
+        R.string.appointment_channel_name,
+        R.string.appointment_channel_description
+      )
+    )
+  }
+
+  fun notifyPresence(context: Context, reminder: PresenceReminder) {
+    post(
+      context,
+      PRESENCE_CHANNEL_ID,
+      reminder.uniqueName.hashCode(),
+      context.getString(R.string.presence_notification_title),
+      context.getString(R.string.presence_notification_text, reminder.subjectName, reminder.startAt.format(TimeFormat))
+    )
+  }
+
+  fun notifyAppointment(context: Context, reminder: AppointmentReminder) {
+    post(
+      context,
+      APPOINTMENT_CHANNEL_ID,
+      reminder.uniqueName.hashCode(),
+      appointmentTitle(context, reminder),
+      appointmentText(context, reminder)
+    )
+  }
+
+  private fun channel(context: Context, id: String, nameRes: Int, descriptionRes: Int): NotificationChannel {
+    require(Build.VERSION.SDK_INT >= Build.VERSION_CODES.O)
+    return NotificationChannel(id, context.getString(nameRes), IMPORTANCE_DEFAULT).apply {
+      description = context.getString(descriptionRes)
+    }
+  }
+
+  private fun post(context: Context, channelId: String, id: Int, title: String, text: String) {
+    if (ContextCompat.checkSelfPermission(context, POST_NOTIFICATIONS) != PERMISSION_GRANTED) return
+
+    val intent = Intent(context, MainActivity::class.java)
+    val pendingIntent = PendingIntent.getActivity(context, id, intent, PendingIntent.FLAG_IMMUTABLE)
+    val notification = NotificationCompat.Builder(context, channelId)
+      .setSmallIcon(R.drawable.ic_notification)
+      .setContentTitle(title)
+      .setContentText(text)
+      .setStyle(NotificationCompat.BigTextStyle().bigText(text))
+      .setContentIntent(pendingIntent)
+      .setAutoCancel(true)
+      .setPriority(NotificationCompat.PRIORITY_DEFAULT)
+      .build()
+
+    NotificationManagerCompat.from(context).notify(id, notification)
+  }
+
+  private fun appointmentTitle(context: Context, reminder: AppointmentReminder): String = when (reminder.daysLeft) {
+    0 -> context.getString(R.string.appointment_notification_title_today, reminder.appointmentName)
+    1 -> context.getString(R.string.appointment_notification_title_tomorrow, reminder.appointmentName)
+    else -> context.getString(R.string.appointment_notification_title_days, reminder.daysLeft, reminder.appointmentName)
+  }
+
+  private fun appointmentText(context: Context, reminder: AppointmentReminder): String {
+    val subject = reminder.subjectName
+    val name = reminder.appointmentName
+    return if (subject != null) {
+      when (reminder.daysLeft) {
+        0 -> context.getString(R.string.appointment_notification_text_today, name, subject)
+        1 -> context.getString(R.string.appointment_notification_text_tomorrow, name, subject)
+        else -> context.getString(R.string.appointment_notification_text_days, reminder.daysLeft, name, subject)
+      }
+    } else {
+      when (reminder.daysLeft) {
+        0 -> context.getString(R.string.appointment_notification_text_today_no_subject, name)
+        1 -> context.getString(R.string.appointment_notification_text_tomorrow_no_subject, name)
+        else -> context.getString(R.string.appointment_notification_text_days_no_subject, reminder.daysLeft, name)
+      }
+    }
+  }
+}

--- a/app/src/main/java/app/jopiter/notification/ReminderScheduler.kt
+++ b/app/src/main/java/app/jopiter/notification/ReminderScheduler.kt
@@ -1,0 +1,98 @@
+/*
+* Jopiter App
+* Copyright (C) 2026 Leonardo Colman Lopes
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU Affero General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU Affero General Public License for more details.
+*
+* You should have received a copy of the GNU Affero General Public License
+* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+package app.jopiter.notification
+
+import android.content.Context
+import androidx.work.ExistingWorkPolicy
+import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.WorkManager
+import androidx.work.workDataOf
+import app.jopiter.calendar.model.Appointment
+import app.jopiter.subject.model.Subject
+import java.time.Duration
+import java.time.LocalDateTime
+import java.util.concurrent.TimeUnit.MILLISECONDS
+import kotlin.math.max
+
+/**
+ * Turns the pure reminder descriptors into scheduled WorkManager jobs. Each sync cancels all work of
+ * its kind by tag and re-enqueues from the current data, so it is idempotent and self-healing across
+ * subject/appointment edits. Individual jobs use unique-work names so a reschedule just replaces them.
+ */
+class ReminderScheduler(
+  private val context: Context,
+  private val now: () -> LocalDateTime = LocalDateTime::now
+) {
+
+  private val workManager: WorkManager get() = WorkManager.getInstance(context)
+
+  fun syncPresence(subjects: List<Subject>) {
+    workManager.cancelAllWorkByTag(TAG_PRESENCE)
+    subjects.forEach { subject ->
+      PresenceReminderScheduler.remindersFor(subject, now()).forEach(::enqueuePresence)
+    }
+  }
+
+  fun syncAppointments(appointments: List<Appointment>, subjectNames: Map<Long, String>) {
+    workManager.cancelAllWorkByTag(TAG_APPOINTMENT)
+    appointments.forEach { appointment ->
+      AppointmentReminderScheduler
+        .remindersFor(appointment, now(), appointment.subjectId?.let(subjectNames::get))
+        .forEach(::enqueueAppointment)
+    }
+  }
+
+  fun enqueuePresence(reminder: PresenceReminder) {
+    val request = OneTimeWorkRequestBuilder<PresenceReminderWorker>()
+      .setInitialDelay(delayMillis(reminder.triggerAt), MILLISECONDS)
+      .setInputData(
+        workDataOf(
+          PresenceReminderWorker.KEY_SUBJECT_ID to reminder.subjectId,
+          PresenceReminderWorker.KEY_SUBJECT_NAME to reminder.subjectName,
+          PresenceReminderWorker.KEY_DAY_OF_WEEK to reminder.dayOfWeek.value,
+          PresenceReminderWorker.KEY_START_AT to reminder.startAt.toString()
+        )
+      )
+      .addTag(TAG_PRESENCE)
+      .build()
+    workManager.enqueueUniqueWork(reminder.uniqueName, ExistingWorkPolicy.REPLACE, request)
+  }
+
+  private fun enqueueAppointment(reminder: AppointmentReminder) {
+    val request = OneTimeWorkRequestBuilder<AppointmentReminderWorker>()
+      .setInitialDelay(delayMillis(reminder.triggerAt), MILLISECONDS)
+      .setInputData(
+        workDataOf(
+          AppointmentReminderWorker.KEY_APPOINTMENT_ID to reminder.appointmentId,
+          AppointmentReminderWorker.KEY_APPOINTMENT_NAME to reminder.appointmentName,
+          AppointmentReminderWorker.KEY_SUBJECT_NAME to reminder.subjectName,
+          AppointmentReminderWorker.KEY_DAYS_LEFT to reminder.daysLeft
+        )
+      )
+      .addTag(TAG_APPOINTMENT)
+      .build()
+    workManager.enqueueUniqueWork(reminder.uniqueName, ExistingWorkPolicy.REPLACE, request)
+  }
+
+  private fun delayMillis(triggerAt: LocalDateTime): Long = max(0, Duration.between(now(), triggerAt).toMillis())
+
+  companion object {
+    const val TAG_PRESENCE = "presence"
+    const val TAG_APPOINTMENT = "appointment"
+  }
+}

--- a/app/src/main/java/app/jopiter/notification/Reminders.kt
+++ b/app/src/main/java/app/jopiter/notification/Reminders.kt
@@ -1,0 +1,45 @@
+/*
+* Jopiter App
+* Copyright (C) 2026 Leonardo Colman Lopes
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU Affero General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU Affero General Public License for more details.
+*
+* You should have received a copy of the GNU Affero General Public License
+* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+package app.jopiter.notification
+
+import java.time.DayOfWeek
+import java.time.LocalDateTime
+import java.time.LocalTime
+
+/** A reminder to confirm attendance, due when one of a subject's weekly classes starts. */
+data class PresenceReminder(
+  val subjectId: Long,
+  val subjectName: String,
+  val dayOfWeek: DayOfWeek,
+  val startAt: LocalTime,
+  val triggerAt: LocalDateTime
+) {
+  /** Stable key identifying this recurring class slot, used as the WorkManager unique-work name. */
+  val uniqueName: String get() = "presence:$subjectId:${dayOfWeek.value}:$startAt"
+}
+
+/** A reminder that an appointment is [daysLeft] days away (0 meaning it is later today). */
+data class AppointmentReminder(
+  val appointmentId: Long,
+  val appointmentName: String,
+  val subjectName: String?,
+  val daysLeft: Int,
+  val triggerAt: LocalDateTime
+) {
+  val uniqueName: String get() = "appointment:$appointmentId:$daysLeft"
+}

--- a/app/src/main/res/drawable/ic_notification.xml
+++ b/app/src/main/res/drawable/ic_notification.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="#FFFFFF">
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M12,22c1.1,0 2,-0.9 2,-2h-4c0,1.1 0.89,2 2,2zM18,16v-5c0,-3.07 -1.64,-5.64 -4.5,-6.32L13.5,4c0,-0.83 -0.67,-1.5 -1.5,-1.5s-1.5,0.67 -1.5,1.5v0.68C7.63,5.36 6,7.92 6,11v5l-2,2v1h16v-1l-2,-2z" />
+</vector>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -83,4 +83,21 @@
     <string name="import_subjects_usp_number">Número USP</string>
     <string name="import_subjects_password">Senha USP</string>
     <string name="import_subjects_error">Não foi possível importar. Verifique suas credenciais e tente novamente.</string>
+
+    <!-- Notifications -->
+    <string name="presence_channel_name">Confirmação de presença</string>
+    <string name="presence_channel_description">Lembretes para confirmar sua presença quando uma aula começa</string>
+    <string name="appointment_channel_name">Compromissos</string>
+    <string name="appointment_channel_description">Lembretes de provas, trabalhos e outros compromissos</string>
+    <string name="presence_notification_title">Confirme sua presença!</string>
+    <string name="presence_notification_text">Toque para confirmar sua presença em %1$s às %2$s.</string>
+    <string name="appointment_notification_title_today">%1$s é hoje!</string>
+    <string name="appointment_notification_title_tomorrow">%1$s é amanhã</string>
+    <string name="appointment_notification_title_days">%1$d dias para %2$s</string>
+    <string name="appointment_notification_text_today">%1$s de %2$s é hoje!</string>
+    <string name="appointment_notification_text_tomorrow">%1$s de %2$s é amanhã!</string>
+    <string name="appointment_notification_text_days">Faltam %1$d dias para %2$s de %3$s.</string>
+    <string name="appointment_notification_text_today_no_subject">%1$s é hoje!</string>
+    <string name="appointment_notification_text_tomorrow_no_subject">%1$s é amanhã!</string>
+    <string name="appointment_notification_text_days_no_subject">Faltam %1$d dias para %2$s.</string>
 </resources>

--- a/app/src/test/java/app/jopiter/notification/AppointmentReminderSchedulerTest.kt
+++ b/app/src/test/java/app/jopiter/notification/AppointmentReminderSchedulerTest.kt
@@ -1,0 +1,67 @@
+/*
+* Jopiter App
+* Copyright (C) 2026 Leonardo Colman Lopes
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU Affero General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU Affero General Public License for more details.
+*
+* You should have received a copy of the GNU Affero General Public License
+* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+package app.jopiter.notification
+
+import app.jopiter.calendar.model.Appointment
+import app.jopiter.calendar.model.AppointmentType
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.shouldBe
+import java.time.LocalDateTime
+
+class AppointmentReminderSchedulerTest : FunSpec({
+
+  val now = LocalDateTime.of(2026, 6, 1, 9, 0)
+
+  fun appointmentAt(dateTime: LocalDateTime, subjectId: Long? = null) =
+    Appointment(id = 5, subjectId = subjectId, name = "Prova P1", dateTime = dateTime, type = AppointmentType.Exam)
+
+  test("warns 30/15/7..1 days and 12h before a far-off appointment") {
+    val appointment = appointmentAt(now.plusDays(40))
+
+    val reminders = AppointmentReminderScheduler.remindersFor(appointment, now)
+
+    reminders.map { it.daysLeft } shouldContainExactly listOf(30, 15, 7, 6, 5, 4, 3, 2, 1, 0)
+    reminders.first { it.daysLeft == 1 }.triggerAt shouldBe appointment.dateTime.minusDays(1)
+    reminders.first { it.daysLeft == 0 }.triggerAt shouldBe appointment.dateTime.minusHours(12)
+  }
+
+  test("only keeps reminders still in the future") {
+    // Appointment in two days: only the 1-day-before and the 12h-before triggers are still ahead.
+    val reminders = AppointmentReminderScheduler.remindersFor(appointmentAt(now.plusDays(2)), now)
+
+    reminders.map { it.daysLeft } shouldContainExactly listOf(1, 0)
+  }
+
+  test("produces nothing for an appointment already in the past") {
+    AppointmentReminderScheduler.remindersFor(appointmentAt(now.minusDays(1)), now).shouldBeEmpty()
+  }
+
+  test("carries the subject name through when provided") {
+    val appointment = appointmentAt(now.plusDays(40), subjectId = 3)
+
+    val reminders = AppointmentReminderScheduler.remindersFor(appointment, now, "Cálculo")
+
+    reminders.forEach { it.subjectName shouldBe "Cálculo" }
+  }
+
+  test("unique name encodes appointment id and days left") {
+    AppointmentReminder(5, "Prova", null, 7, now).uniqueName shouldBe "appointment:5:7"
+  }
+})

--- a/app/src/test/java/app/jopiter/notification/PresenceReminderSchedulerTest.kt
+++ b/app/src/test/java/app/jopiter/notification/PresenceReminderSchedulerTest.kt
@@ -1,0 +1,73 @@
+/*
+* Jopiter App
+* Copyright (C) 2026 Leonardo Colman Lopes
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU Affero General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU Affero General Public License for more details.
+*
+* You should have received a copy of the GNU Affero General Public License
+* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+package app.jopiter.notification
+
+import app.jopiter.subject.model.ClassTime
+import app.jopiter.subject.model.Subject
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.shouldBe
+import java.time.DayOfWeek.MONDAY
+import java.time.DayOfWeek.WEDNESDAY
+import java.time.LocalDateTime
+import java.time.LocalTime
+
+class PresenceReminderSchedulerTest : FunSpec({
+
+  // 2026-06-29 is a Monday.
+  val mondayMorning = LocalDateTime.of(2026, 6, 29, 7, 0)
+
+  test("next occurrence is today when the class has not started yet") {
+    PresenceReminderScheduler.nextOccurrence(MONDAY, LocalTime.of(8, 0), mondayMorning) shouldBe
+      LocalDateTime.of(2026, 6, 29, 8, 0)
+  }
+
+  test("next occurrence rolls to next week once the class start has passed") {
+    val afterClass = LocalDateTime.of(2026, 6, 29, 9, 0)
+
+    PresenceReminderScheduler.nextOccurrence(MONDAY, LocalTime.of(8, 0), afterClass) shouldBe
+      LocalDateTime.of(2026, 7, 6, 8, 0)
+  }
+
+  test("next occurrence finds the upcoming weekday later in the week") {
+    PresenceReminderScheduler.nextOccurrence(WEDNESDAY, LocalTime.of(10, 0), mondayMorning) shouldBe
+      LocalDateTime.of(2026, 7, 1, 10, 0)
+  }
+
+  test("builds one reminder per class time with the subject metadata") {
+    val subject = Subject(
+      id = 42,
+      name = "Cálculo",
+      classTimes = listOf(
+        ClassTime(MONDAY, LocalTime.of(8, 0), LocalTime.of(10, 0)),
+        ClassTime(WEDNESDAY, LocalTime.of(10, 0), LocalTime.of(12, 0))
+      )
+    )
+
+    val reminders = PresenceReminderScheduler.remindersFor(subject, mondayMorning)
+
+    reminders.shouldContainExactlyInAnyOrder(
+      PresenceReminder(42, "Cálculo", MONDAY, LocalTime.of(8, 0), LocalDateTime.of(2026, 6, 29, 8, 0)),
+      PresenceReminder(42, "Cálculo", WEDNESDAY, LocalTime.of(10, 0), LocalDateTime.of(2026, 7, 1, 10, 0))
+    )
+  }
+
+  test("unique name encodes subject, weekday and start time") {
+    PresenceReminder(7, "x", MONDAY, LocalTime.of(8, 0), mondayMorning).uniqueName shouldBe "presence:7:1:08:00"
+  }
+})

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,7 @@
 [versions]
 fuel = "3.0.0-alpha1"
 okhttp = "5.0.0-alpha.10"
+work = "2.9.0"
 sqlDelight = "2.0.1"
 android-gradle = "8.0.2"
 kotlin = "1.9.20"
@@ -16,6 +17,7 @@ android-gradle = { module = "com.android.tools.build:gradle", version.ref = "and
 fuel = { module = "com.github.kittinunf.fuel:fuel", version.ref = "fuel" }
 fuel-jackson-jvm = { module = "com.github.kittinunf.fuel:fuel-jackson-jvm", version.ref = "fuel" }
 okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }
+work-runtime = { module = "androidx.work:work-runtime-ktx", version.ref = "work" }
 kotlin-gradle-plugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
 sqldelight-android-driver = { module = "app.cash.sqldelight:android-driver", version.ref = "sqlDelight" }
 sqdelight-sqlite-driver = { module = "app.cash.sqldelight:sqlite-driver", version.ref = "sqlDelight" }


### PR DESCRIPTION
## What

Brings the legacy **reminder notifications** into the modern app, re-implemented on **WorkManager** (replacing the legacy Evernote `android-job` + job junction tables). Two kinds:

- **Presence reminders** — when a class starts, "confirm your presence in _X_ at _HH:mm_". Recurs weekly.
- **Appointment reminders** — 30 / 15 / 7…1 days before, plus a 12h same-day nudge (legacy cadence preserved), with subject-aware copy.

## How

- **`PresenceReminderScheduler`** (pure) — one reminder per weekly class, due the next time that class starts; reused for both the initial schedule and the weekly reschedule the worker performs after firing.
- **`AppointmentReminderScheduler`** (pure) — future-only reminders at the legacy offsets.
- **`ReminderScheduler`** — turns descriptors into WorkManager jobs (unique-work names; cancel-by-tag + re-enqueue on each sync ⇒ idempotent and self-healing).
- **`PresenceReminderWorker` / `AppointmentReminderWorker`** — thin `CoroutineWorker`s that read `inputData` and post via **`ReminderNotifications`** (creates O+ channels, posting gated by `POST_NOTIFICATIONS`).
- **`ReminderCoordinator`** — observes the subject & appointment flows and re-schedules on any create/edit/delete. Started from `JopiterApplication`.
- `POST_NOTIFICATIONS` declared in the manifest and requested at runtime on Android 13+ (`MainActivity`).

## Schema

**No schema change.**

## Tests

Pure schedulers, thoroughly:
- `PresenceReminderSchedulerTest` — next occurrence today / rolls to next week after start / upcoming weekday; one reminder per class time; unique-name encoding.
- `AppointmentReminderSchedulerTest` — full 30/15/7..1/12h cadence, future-only filtering, past appointment yields nothing, subject-name pass-through.

## Validation

- `:app:testUnofficialDebugUnitTest`, `:app:detekt`, `:app:spotlessCheck`, `:app:assembleUnofficialDebug` green (JDK 17).
- Emulator (Pixel, API 36): both channels created at startup (`presence_reminders`, `appointment_reminders`); `POST_NOTIFICATIONS` requested/granted; WorkManager jobs scheduled in JobScheduler with the correct delays (next Tue 08:00, Fri 19:00 for the seeded subjects); force-running a job posts a real notification — *"Confirme sua presença! Toque para confirmar sua presença em a às 19:00."* with the app's notification icon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)