### PR TITLE
Phase 7: Home dashboard

### DIFF
--- a/app/src/main/java/app/jopiter/JopiterApplication.kt
+++ b/app/src/main/java/app/jopiter/JopiterApplication.kt
@@ -20,6 +20,7 @@ package app.jopiter
 import android.app.Application
 import app.cash.sqldelight.driver.android.AndroidSqliteDriver
 import app.jopiter.calendar.calendarModule
+import app.jopiter.home.homeModule
 import app.jopiter.notification.ReminderCoordinator
 import app.jopiter.notification.ReminderNotifications
 import app.jopiter.notification.notificationModule
@@ -41,6 +42,7 @@ class JopiterApplication : Application() {
       modules(subjectModule)
       modules(calendarModule)
       modules(notificationModule)
+      modules(homeModule)
       modules(module {
         single { Database(AndroidSqliteDriver(Database.Schema, get(), "Database")) }
       })

--- a/app/src/main/java/app/jopiter/home/HomeAggregator.kt
+++ b/app/src/main/java/app/jopiter/home/HomeAggregator.kt
@@ -1,0 +1,49 @@
+/*
+* Jopiter App
+* Copyright (C) 2026 Leonardo Colman Lopes
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU Affero General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU Affero General Public License for more details.
+*
+* You should have received a copy of the GNU Affero General Public License
+* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+package app.jopiter.home
+
+import app.jopiter.restaurant.model.RestaurantMenu
+import app.jopiter.subject.model.ClassTime
+import app.jopiter.subject.model.Subject
+import java.time.LocalDate
+
+/** One of today's classes, with whether the student has already marked themselves present. */
+data class TodayClass(val subject: Subject, val classTime: ClassTime, val present: Boolean)
+
+/**
+ * Pure aggregation behind the Home dashboard: what happens today. No Android or IO dependencies, so
+ * it is fully unit-testable.
+ */
+object HomeAggregator {
+
+  /** The classes happening today, in start-time order, each flagged with today's presence. */
+  fun todayClasses(
+    subjects: List<Subject>,
+    attendance: Map<Long, Set<LocalDate>>,
+    today: LocalDate
+  ): List<TodayClass> =
+    subjects.flatMap { subject ->
+      subject.classTimes
+        .filter { it.dayOfWeek == today.dayOfWeek }
+        .map { classTime -> TodayClass(subject, classTime, today in attendance[subject.id].orEmpty()) }
+    }.sortedBy { it.classTime.startAt }
+
+  /** Today's non-empty menus, lunch before dinner. */
+  fun todayMenus(menus: List<RestaurantMenu>, today: LocalDate): List<RestaurantMenu> =
+    menus.filter { it.date == today && !it.isEmpty() }.sortedBy { it.period }
+}

--- a/app/src/main/java/app/jopiter/home/HomeModule.kt
+++ b/app/src/main/java/app/jopiter/home/HomeModule.kt
@@ -15,14 +15,11 @@
 * You should have received a copy of the GNU Affero General Public License
 * along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
-package app.jopiter.restaurant.repository
+package app.jopiter.home
 
-import app.jopiter.restaurant.external.JopiterRestaurantClient
-import app.jopiter.restaurant.model.RestaurantMenu
+import org.koin.androidx.viewmodel.dsl.viewModel
+import org.koin.dsl.module
 
-open class RestaurantItemRepository(private val jopiterClient: JopiterRestaurantClient) {
-
-  open fun getRestaurantItems(restaurantId: Int): List<RestaurantMenu> {
-    return jopiterClient.fetchItems(restaurantId).getOrNull().orEmpty()
-  }
+val homeModule = module {
+  viewModel { HomeViewModel(get(), get(), get(), get()) }
 }

--- a/app/src/main/java/app/jopiter/home/HomePage.kt
+++ b/app/src/main/java/app/jopiter/home/HomePage.kt
@@ -1,0 +1,116 @@
+/*
+* Jopiter App
+* Copyright (C) 2026 Leonardo Colman Lopes
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU Affero General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU Affero General Public License for more details.
+*
+* You should have received a copy of the GNU Affero General Public License
+* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+package app.jopiter.home
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.Card
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Switch
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import app.jopiter.R
+import app.jopiter.common.TimeFormat
+import app.jopiter.common.displayNameRes
+import app.jopiter.restaurant.labelRes
+import app.jopiter.restaurant.model.RestaurantMenu
+import org.koin.androidx.compose.koinViewModel
+
+@Composable
+fun HomePage(viewModel: HomeViewModel = koinViewModel()) {
+  val state by viewModel.state.collectAsState()
+
+  LazyColumn(
+    modifier = Modifier.fillMaxSize().testTag("home_content"),
+    contentPadding = PaddingValues(16.dp),
+    verticalArrangement = Arrangement.spacedBy(12.dp)
+  ) {
+    item { SectionTitle(stringResource(R.string.home_today_classes)) }
+    if (state.classes.isEmpty()) {
+      item { Text(stringResource(R.string.home_no_classes), style = MaterialTheme.typography.body2) }
+    } else {
+      items(state.classes) { todayClass ->
+        TodayClassCard(todayClass) { viewModel.toggleTodayPresence(todayClass.subject.id) }
+      }
+    }
+
+    item { SectionTitle(stringResource(R.string.home_menu_title, state.preferredRestaurant.name)) }
+    if (state.menus.isEmpty()) {
+      item { Text(stringResource(R.string.home_no_menu), style = MaterialTheme.typography.body2) }
+    } else {
+      items(state.menus) { menu -> MenuSummaryCard(menu) }
+    }
+  }
+}
+
+@Composable
+private fun SectionTitle(text: String) {
+  Text(text, style = MaterialTheme.typography.h6, modifier = Modifier.testTag("section_title"))
+}
+
+@Composable
+private fun TodayClassCard(todayClass: TodayClass, onTogglePresence: () -> Unit) {
+  Card(Modifier.fillMaxWidth().testTag("today_class"), elevation = 2.dp) {
+    Column(Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(4.dp)) {
+      Text(todayClass.subject.name, style = MaterialTheme.typography.subtitle1)
+      Text(
+        stringResource(
+          R.string.class_time_summary,
+          stringResource(todayClass.classTime.dayOfWeek.displayNameRes),
+          todayClass.classTime.startAt.format(TimeFormat),
+          todayClass.classTime.endAt.format(TimeFormat)
+        ),
+        style = MaterialTheme.typography.body2
+      )
+      Row(Modifier.fillMaxWidth(), Arrangement.SpaceBetween, Alignment.CenterVertically) {
+        Text(stringResource(R.string.present_today), style = MaterialTheme.typography.body2)
+        Switch(
+          checked = todayClass.present,
+          onCheckedChange = { onTogglePresence() },
+          modifier = Modifier.testTag("home_presence_toggle")
+        )
+      }
+    }
+  }
+}
+
+@Composable
+private fun MenuSummaryCard(menu: RestaurantMenu) {
+  Card(Modifier.fillMaxWidth().testTag("home_menu"), elevation = 2.dp) {
+    Column(Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(4.dp)) {
+      Text(stringResource(menu.period.labelRes), style = MaterialTheme.typography.subtitle1)
+      menu.mainItem?.let { Text(it.item, style = MaterialTheme.typography.body2) }
+      menu.vegetarianItem?.let { Text(it.item, style = MaterialTheme.typography.body2) }
+      menu.dessertItem?.let { Text(it.item, style = MaterialTheme.typography.body2) }
+    }
+  }
+}

--- a/app/src/main/java/app/jopiter/home/HomeViewModel.kt
+++ b/app/src/main/java/app/jopiter/home/HomeViewModel.kt
@@ -1,0 +1,92 @@
+/*
+* Jopiter App
+* Copyright (C) 2026 Leonardo Colman Lopes
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU Affero General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU Affero General Public License for more details.
+*
+* You should have received a copy of the GNU Affero General Public License
+* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+package app.jopiter.home
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import app.jopiter.restaurant.model.Restaurant
+import app.jopiter.restaurant.model.RestaurantMenu
+import app.jopiter.restaurant.repository.PreferredRestaurantRepository
+import app.jopiter.restaurant.repository.RestaurantItemRepository
+import app.jopiter.subject.repository.PresenceRepository
+import app.jopiter.subject.repository.SubjectRepository
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.flow.mapLatest
+import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.flow.stateIn
+import java.time.LocalDate
+
+/** Everything the Home dashboard shows for today. */
+data class HomeState(
+  val today: LocalDate,
+  val classes: List<TodayClass>,
+  val menus: List<RestaurantMenu>,
+  val preferredRestaurant: Restaurant
+)
+
+/**
+ * Aggregates the day's overview — today's classes (with a presence toggle) and today's menu at the
+ * preferred restaurant — by reusing the Subject, Presence and Restaurant repositories. The heavy
+ * lifting is delegated to the pure [HomeAggregator].
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class HomeViewModel(
+  subjectRepository: SubjectRepository,
+  private val presenceRepository: PresenceRepository,
+  preferredRestaurantRepository: PreferredRestaurantRepository,
+  private val restaurantItemRepository: RestaurantItemRepository,
+  private val today: () -> LocalDate = LocalDate::now
+) : ViewModel() {
+
+  private val classes = combine(
+    subjectRepository.subjects,
+    presenceRepository.attendanceBySubject
+  ) { subjects, attendance ->
+    HomeAggregator.todayClasses(subjects, attendance, today())
+  }
+
+  // Seeded so the (local, instant) class list is not gated behind the restaurant network fetch;
+  // the real menus replace the seed once loaded.
+  @Suppress("InjectDispatcher")
+  private val menus = preferredRestaurantRepository.preferredRestaurant
+    .mapLatest { restaurant ->
+      restaurant to HomeAggregator.todayMenus(restaurantItemRepository.getRestaurantItems(restaurant.id), today())
+    }
+    .onStart { emit(Restaurant.DefaultRestaurant to emptyList()) }
+    .flowOn(Dispatchers.IO)
+
+  val state: StateFlow<HomeState> =
+    combine(classes, menus) { todayClasses, (restaurant, todayMenus) ->
+      HomeState(today(), todayClasses, todayMenus, restaurant)
+    }.stateIn(
+      viewModelScope,
+      SharingStarted.WhileSubscribed(STOP_TIMEOUT_MS),
+      HomeState(today(), emptyList(), emptyList(), Restaurant.DefaultRestaurant)
+    )
+
+  fun toggleTodayPresence(subjectId: Long) = presenceRepository.togglePresent(subjectId, today())
+
+  private companion object {
+    const val STOP_TIMEOUT_MS = 5000L
+  }
+}

--- a/app/src/main/java/app/jopiter/navigation/JopiterNavHost.kt
+++ b/app/src/main/java/app/jopiter/navigation/JopiterNavHost.kt
@@ -17,16 +17,15 @@
 */
 package app.jopiter.navigation
 
-import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.testTag
 import androidx.navigation.NavHostController
 import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.navArgument
 import app.jopiter.calendar.CalendarPage
+import app.jopiter.home.HomePage
 import app.jopiter.restaurant.RestaurantPage
 import app.jopiter.subject.SubjectEditScreen
 import app.jopiter.subject.SubjectNotesScreen
@@ -39,7 +38,7 @@ import app.jopiter.subject.SubjectsPage
 @Composable
 fun JopiterNavHost(navController: NavHostController, modifier: Modifier = Modifier) {
   NavHost(navController, startDestination = Page.Home.route, modifier = modifier) {
-    composable(Page.Home.route) { Text("Home", Modifier.testTag("home_content")) }
+    composable(Page.Home.route) { HomePage() }
 
     composable(Page.Subjects.route) {
       SubjectsPage(

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -100,4 +100,10 @@
     <string name="appointment_notification_text_today_no_subject">%1$s é hoje!</string>
     <string name="appointment_notification_text_tomorrow_no_subject">%1$s é amanhã!</string>
     <string name="appointment_notification_text_days_no_subject">Faltam %1$d dias para %2$s.</string>
+
+    <!-- Home -->
+    <string name="home_today_classes">Aulas de hoje</string>
+    <string name="home_no_classes">Nenhuma aula hoje</string>
+    <string name="home_menu_title">Cardápio de hoje · %1$s</string>
+    <string name="home_no_menu">Cardápio de hoje indisponível</string>
 </resources>

--- a/app/src/test/java/app/jopiter/home/HomeAggregatorTest.kt
+++ b/app/src/test/java/app/jopiter/home/HomeAggregatorTest.kt
@@ -1,0 +1,86 @@
+/*
+* Jopiter App
+* Copyright (C) 2026 Leonardo Colman Lopes
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU Affero General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU Affero General Public License for more details.
+*
+* You should have received a copy of the GNU Affero General Public License
+* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+package app.jopiter.home
+
+import app.jopiter.restaurant.model.RestaurantMenu
+import app.jopiter.restaurant.model.RestaurantMenu.Period
+import app.jopiter.subject.model.ClassTime
+import app.jopiter.subject.model.Subject
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.shouldBe
+import java.time.DayOfWeek.MONDAY
+import java.time.DayOfWeek.TUESDAY
+import java.time.LocalDate
+import java.time.LocalTime
+
+class HomeAggregatorTest : FunSpec({
+
+  // 2026-06-29 is a Monday.
+  val monday = LocalDate.of(2026, 6, 29)
+
+  fun classTime(day: java.time.DayOfWeek, hour: Int) = ClassTime(day, LocalTime.of(hour, 0), LocalTime.of(hour + 2, 0))
+
+  fun menu(period: Period, date: LocalDate = monday, empty: Boolean = false) = RestaurantMenu(
+    restaurantName = "RU",
+    restaurantId = 6,
+    date = date,
+    period = period,
+    calories = 0,
+    mainItem = null,
+    vegetarianItem = null,
+    dessertItem = null,
+    mundaneItems = if (empty) emptyList() else listOf("Arroz")
+  )
+
+  context("today's classes") {
+    test("keeps only classes on today's weekday, ordered by start time, flagged with presence") {
+      val subjects = listOf(
+        Subject(id = 1, name = "Física", classTimes = listOf(classTime(MONDAY, 10))),
+        Subject(id = 2, name = "Cálculo", classTimes = listOf(classTime(MONDAY, 8), classTime(TUESDAY, 8)))
+      )
+      val attendance = mapOf(2L to setOf(monday))
+
+      val today = HomeAggregator.todayClasses(subjects, attendance, monday)
+
+      today.map { it.subject.name } shouldBe listOf("Cálculo", "Física")
+      today.map { it.classTime.dayOfWeek } shouldBe listOf(MONDAY, MONDAY)
+      today.first().present shouldBe true
+      today.last().present shouldBe false
+    }
+
+    test("is empty when no class falls on today") {
+      val subjects = listOf(Subject(id = 1, name = "Cálculo", classTimes = listOf(classTime(TUESDAY, 8))))
+
+      HomeAggregator.todayClasses(subjects, emptyMap(), monday).shouldBeEmpty()
+    }
+  }
+
+  context("today's menus") {
+    test("keeps today's non-empty menus, lunch before dinner") {
+      val menus = listOf(
+        menu(Period.Dinner),
+        menu(Period.Lunch),
+        menu(Period.Lunch, date = monday.plusDays(1)),
+        menu(Period.Lunch, empty = true)
+      )
+
+      HomeAggregator.todayMenus(menus, monday).map { it.period } shouldBe listOf(Period.Lunch, Period.Dinner)
+    }
+  }
+})

--- a/app/src/test/java/app/jopiter/home/HomeViewModelTest.kt
+++ b/app/src/test/java/app/jopiter/home/HomeViewModelTest.kt
@@ -1,0 +1,102 @@
+/*
+* Jopiter App
+* Copyright (C) 2026 Leonardo Colman Lopes
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU Affero General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU Affero General Public License for more details.
+*
+* You should have received a copy of the GNU Affero General Public License
+* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+package app.jopiter.home
+
+import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver
+import app.jopiter.Database
+import app.jopiter.restaurant.external.JopiterRestaurantClient
+import app.jopiter.restaurant.model.RestaurantMenu
+import app.jopiter.restaurant.model.RestaurantMenu.Period
+import app.jopiter.restaurant.repository.PreferredRestaurantRepository
+import app.jopiter.restaurant.repository.RestaurantItemRepository
+import app.jopiter.subject.model.ClassTime
+import app.jopiter.subject.model.Subject
+import app.jopiter.subject.repository.PresenceRepository
+import app.jopiter.subject.repository.SubjectRepository
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import java.time.DayOfWeek.MONDAY
+import java.time.DayOfWeek.TUESDAY
+import java.time.LocalDate
+import java.time.LocalTime
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class HomeViewModelTest : FunSpec({
+
+  beforeTest { Dispatchers.setMain(UnconfinedTestDispatcher()) }
+  afterTest { Dispatchers.resetMain() }
+
+  // 2026-06-29 is a Monday.
+  val monday = LocalDate.of(2026, 6, 29)
+
+  class FakeItemRepository(private val menus: List<RestaurantMenu>) :
+    RestaurantItemRepository(JopiterRestaurantClient("http://localhost")) {
+    override fun getRestaurantItems(restaurantId: Int) = menus
+  }
+
+  fun menu(period: Period) = RestaurantMenu("RU", 6, monday, period, 0, null, null, null, listOf("Arroz"))
+
+  data class Fixture(val subjects: SubjectRepository, val viewModel: HomeViewModel)
+
+  fun fixture(menus: List<RestaurantMenu> = emptyList()): Fixture {
+    val driver = JdbcSqliteDriver(JdbcSqliteDriver.IN_MEMORY)
+    Database.Schema.create(driver)
+    val database = Database(driver)
+    val subjects = SubjectRepository(database.subjectQueries, database.classTimeQueries)
+    val presence = PresenceRepository(database.presenceQueries)
+    val preferred = PreferredRestaurantRepository(database.preferredRestaurantQueries)
+    val viewModel = HomeViewModel(subjects, presence, preferred, FakeItemRepository(menus), today = { monday })
+    return Fixture(subjects, viewModel)
+  }
+
+  test("exposes today's classes and today's menus") {
+    val (subjects, viewModel) = fixture(listOf(menu(Period.Dinner), menu(Period.Lunch)))
+    subjects.save(
+      Subject(
+        name = "Cálculo",
+        classTimes = listOf(
+          ClassTime(MONDAY, LocalTime.of(8, 0), LocalTime.of(10, 0)),
+          ClassTime(TUESDAY, LocalTime.of(8, 0), LocalTime.of(10, 0))
+        )
+      )
+    )
+
+    val state = viewModel.state.first { it.classes.isNotEmpty() }
+
+    state.classes.single().subject.name shouldBe "Cálculo"
+    state.classes.single().classTime.dayOfWeek shouldBe MONDAY
+    state.menus.map { it.period } shouldBe listOf(Period.Lunch, Period.Dinner)
+  }
+
+  test("toggling presence marks the student present for today") {
+    val (subjects, viewModel) = fixture()
+    val id = subjects.save(
+      Subject(name = "Cálculo", classTimes = listOf(ClassTime(MONDAY, LocalTime.of(8, 0), LocalTime.of(10, 0))))
+    )
+
+    viewModel.toggleTodayPresence(id)
+
+    viewModel.state.first { it.classes.singleOrNull()?.present == true }.classes.single().present shouldBe true
+  }
+})


### PR DESCRIPTION
## What

Replaces the `Text("Home")` placeholder with a real **dashboard** — the day at a glance — reusing the Subject, Presence and Restaurant repositories.

- **Today's classes** — the classes on today's weekday, ordered by start time, each with a **presence toggle**.
- **Today's menu** — lunch and dinner at the preferred restaurant.

## How

- **`HomeAggregator`** (pure) — `todayClasses(subjects, attendance, today)` and `todayMenus(menus, today)`; no Android/IO, fully unit-tested.
- **`HomeViewModel`** — combines the subject + presence flows with the preferred restaurant's menu. The menu flow is **seeded via `onStart`** so the instant local class list isn't gated behind the restaurant network fetch (without it, Home briefly flashed "no classes today" while the menu loaded).
- **`HomePage`** — both sections + per-class presence `Switch`; wired as the Home route in `JopiterNavHost` (placeholder removed).
- `RestaurantItemRepository` made `open` so the ViewModel test can fake the menu feed (same seam pattern as earlier phases).

## Schema

**No schema change.**

## Tests

- `HomeAggregatorTest` — today-only filtering, start-time ordering, presence flag; menu lunch-before-dinner ordering with empty/other-day exclusion.
- `HomeViewModelTest` — today's classes + menus via an in-memory DB and a fake `RestaurantItemRepository`; presence toggle marks the student present.

## Validation

- `:app:testUnofficialDebugUnitTest`, `:app:detekt`, `:app:spotlessCheck`, `:app:assembleUnofficialDebug` green (JDK 17).
- Emulator (Pixel, API 36): Home shows today's class (Cálculo, Terça 08:00–10:00, presence toggle) and today's menu at EACH (Almoço + Jantar with real items); classes render immediately, menus fill in when the fetch completes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)