### PR TITLE
CI: Play Store release pipeline (git-secret + fastlane)

### DIFF
--- a/.github/workflows/release.main.kts
+++ b/.github/workflows/release.main.kts
@@ -1,0 +1,113 @@
+#!/usr/bin/env kotlin
+@file:Repository("https://repo1.maven.org/maven2/")
+@file:Repository("https://central.sonatype.com/repository/maven-snapshots/")
+@file:DependsOn("io.github.typesafegithub:github-workflows-kt:4.0.0-SNAPSHOT")
+
+@file:Repository("https://bindings.krzeminski.it")
+@file:DependsOn("actions:checkout:v4")
+@file:DependsOn("actions:setup-java:v5")
+@file:DependsOn("gradle:actions__setup-gradle:v4")
+@file:DependsOn("entrostat:git-secret-action:v4")
+@file:DependsOn("ruby:setup-ruby:v1")
+@file:DependsOn("softprops:action-gh-release:v2")
+
+import io.github.typesafegithub.workflows.actions.actions.Checkout
+import io.github.typesafegithub.workflows.actions.actions.SetupJava
+import io.github.typesafegithub.workflows.actions.entrostat.GitSecretAction
+import io.github.typesafegithub.workflows.actions.gradle.ActionsSetupGradle
+import io.github.typesafegithub.workflows.actions.ruby.SetupRuby
+import io.github.typesafegithub.workflows.actions.softprops.ActionGhRelease
+import io.github.typesafegithub.workflows.domain.Mode
+import io.github.typesafegithub.workflows.domain.Permission
+import io.github.typesafegithub.workflows.domain.RunnerType.UbuntuLatest
+import io.github.typesafegithub.workflows.domain.triggers.Push
+import io.github.typesafegithub.workflows.dsl.expressions.Contexts
+import io.github.typesafegithub.workflows.dsl.expressions.expr
+import io.github.typesafegithub.workflows.dsl.workflow
+
+// Secrets (configure in the repository settings):
+//   GPG_KEY     — armored GPG private key that decrypts the git-secret files
+//                 (jopiter-key.jks, keystore.properties, fastlane/google-play.json)
+//   RELEASE_KEY — SSH private key of a deploy key with write access, to push the version bump
+val GPG_KEY by Contexts.secrets
+val RELEASE_KEY by Contexts.secrets
+
+workflow(
+  name = "Release",
+  on = listOf(Push(branches = listOf("main"))),
+  sourceFile = __FILE__,
+) {
+  job(
+    id = "release",
+    runsOn = UbuntuLatest,
+    permissions = mapOf(Permission.Contents to Mode.Write),
+  ) {
+    run(
+      name = "Configure Git identity",
+      command = """
+        git config --global user.name "github-actions[bot]"
+        git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+      """.trimIndent(),
+    )
+
+    uses(name = "Set up JDK", action = SetupJava(javaVersion = "17", distribution = SetupJava.Distribution.Adopt))
+    uses(name = "Set up Gradle", action = ActionsSetupGradle())
+
+    uses(
+      name = "Checkout",
+      action = Checkout(sshKey = expr { RELEASE_KEY }, fetchDepth = Checkout.FetchDepth.Infinite),
+    )
+
+    uses(name = "Reveal secrets", action = GitSecretAction(gpgPrivateKey = expr { GPG_KEY }))
+
+    run(
+      name = "Determine bump type and changelog",
+      command = """
+        message=${'$'}(git log -1 --pretty=%B)
+        case "${'$'}message" in
+          *'#major'*) echo "type=major" >> "${'$'}GITHUB_ENV" ;;
+          *'#minor'*) echo "type=minor" >> "${'$'}GITHUB_ENV" ;;
+          *)          echo "type=patch" >> "${'$'}GITHUB_ENV" ;;
+        esac
+        echo "changelog=${'$'}(git log -1 --pretty=%s)" >> "${'$'}GITHUB_ENV"
+      """.trimIndent(),
+    )
+
+    val bump = run(
+      name = "Bump version, tag and push",
+      command = "kotlin app/bump_version.main.kts \"${'$'}type\" \"${'$'}changelog\"",
+    )
+
+    run(
+      name = "Build signed APK for the GitHub release",
+      command = "./gradlew assembleOfficialRelease",
+    )
+
+    uses(
+      name = "Create GitHub release",
+      action = ActionGhRelease(
+        tagName = expr { bump.outputs["version"] },
+        name = expr { bump.outputs["version"] },
+        draft = false,
+        files = listOf(
+          "app/build/outputs/apk/official/release/app-official-release.apk",
+          "app/build/outputs/mapping/officialRelease/mapping.txt",
+          "app/build/outputs/mapping/officialRelease/configuration.txt",
+          "app/build/outputs/mapping/officialRelease/seeds.txt",
+          "app/build/outputs/mapping/officialRelease/usage.txt",
+        ),
+      ),
+    )
+
+    uses(name = "Set up Ruby", action = SetupRuby(rubyVersion = "3.2.3"))
+
+    run(
+      name = "Publish to Play Store",
+      workingDirectory = "fastlane",
+      command = """
+        bundle install --jobs 4 --retry 3
+        bundle exec fastlane playstore
+      """.trimIndent(),
+    )
+  }
+}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,95 @@
+# This file was generated using Kotlin DSL (.github/workflows/release.main.kts).
+# If you want to modify the workflow, please change the Kotlin file and regenerate this YAML file.
+# Generated with https://github.com/typesafegithub/github-workflows-kt
+
+name: 'Release'
+on:
+  push:
+    branches:
+    - 'main'
+jobs:
+  check_yaml_consistency:
+    name: 'Check YAML consistency'
+    runs-on: 'ubuntu-latest'
+    steps:
+    - id: 'step-0'
+      name: 'Check out'
+      uses: 'actions/checkout@v4'
+    - id: 'step-1'
+      name: 'Execute script'
+      run: 'rm ''.github/workflows/release.yaml'' && ''.github/workflows/release.main.kts'''
+    - id: 'step-2'
+      name: 'Consistency check'
+      run: 'git diff --exit-code ''.github/workflows/release.yaml'''
+  release:
+    runs-on: 'ubuntu-latest'
+    permissions:
+      contents: 'write'
+    needs:
+    - 'check_yaml_consistency'
+    steps:
+    - id: 'step-0'
+      name: 'Configure Git identity'
+      run: |-
+        git config --global user.name "github-actions[bot]"
+        git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+    - id: 'step-1'
+      name: 'Set up JDK'
+      uses: 'actions/setup-java@v5'
+      with:
+        java-version: '17'
+        distribution: 'adopt'
+    - id: 'step-2'
+      name: 'Set up Gradle'
+      uses: 'gradle/actions/setup-gradle@v4'
+    - id: 'step-3'
+      name: 'Checkout'
+      uses: 'actions/checkout@v4'
+      with:
+        ssh-key: '${{ secrets.RELEASE_KEY }}'
+        fetch-depth: '0'
+    - id: 'step-4'
+      name: 'Reveal secrets'
+      uses: 'entrostat/git-secret-action@v4'
+      with:
+        gpg-private-key: '${{ secrets.GPG_KEY }}'
+    - id: 'step-5'
+      name: 'Determine bump type and changelog'
+      run: |-
+        message=$(git log -1 --pretty=%B)
+        case "$message" in
+          *'#major'*) echo "type=major" >> "$GITHUB_ENV" ;;
+          *'#minor'*) echo "type=minor" >> "$GITHUB_ENV" ;;
+          *)          echo "type=patch" >> "$GITHUB_ENV" ;;
+        esac
+        echo "changelog=$(git log -1 --pretty=%s)" >> "$GITHUB_ENV"
+    - id: 'step-6'
+      name: 'Bump version, tag and push'
+      run: 'kotlin app/bump_version.main.kts "$type" "$changelog"'
+    - id: 'step-7'
+      name: 'Build signed APK for the GitHub release'
+      run: './gradlew assembleOfficialRelease'
+    - id: 'step-8'
+      name: 'Create GitHub release'
+      uses: 'softprops/action-gh-release@v2'
+      with:
+        name: '${{ steps.step-6.outputs.version }}'
+        tag_name: '${{ steps.step-6.outputs.version }}'
+        draft: 'false'
+        files: |-
+          app/build/outputs/apk/official/release/app-official-release.apk
+          app/build/outputs/mapping/officialRelease/mapping.txt
+          app/build/outputs/mapping/officialRelease/configuration.txt
+          app/build/outputs/mapping/officialRelease/seeds.txt
+          app/build/outputs/mapping/officialRelease/usage.txt
+    - id: 'step-9'
+      name: 'Set up Ruby'
+      uses: 'ruby/setup-ruby@v1'
+      with:
+        ruby-version: '3.2.3'
+    - id: 'step-10'
+      name: 'Publish to Play Store'
+      working-directory: 'fastlane'
+      run: |-
+        bundle install --jobs 4 --retry 3
+        bundle exec fastlane playstore

--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,11 @@ local.properties
 !*.secret
 jopiter-key.jks
 keystore.properties
+
+# Play Store service account (decrypted by git-secret in CI) and fastlane artifacts
 fastlane/google-play.json
+fastlane/report.xml
+fastlane/Preview.html
+fastlane/vendor/
+.bundle/
+vendor/bundle/

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,58 @@
+# Publicação (Play Store)
+
+A publicação segue o mesmo modelo do app Petals: **GitHub Actions + git-secret + fastlane**.
+O workflow [`.github/workflows/release.yaml`](.github/workflows/release.yaml) (gerado a partir de
+`release.main.kts`) roda **automaticamente a cada push na `main`** e:
+
+1. Revela os segredos cifrados com **git-secret** (keystore + credenciais + service account da Play).
+2. **Sobe a versão** (semver) reescrevendo `versionCode`/`versionName` em `app/build.gradle.kts`,
+   escreve o changelog, faz commit `[skip ci]`, cria a tag e dá push na `main`.
+3. Builda o **APK assinado** (flavor `official`) e cria um **GitHub Release** com o APK + mapping do R8.
+4. Builda o **AAB assinado** e publica na **Play Store, faixa `production`**, via `fastlane`.
+
+> ⚠️ Todo merge na `main` publica em **produção**. Para pausar, desabilite o workflow "Release" em
+> Actions, ou troque a faixa para `internal` na lane do `fastlane/Fastfile`.
+
+## Assinatura / versão
+
+- Tipo de bump: **patch** por padrão. Inclua `#minor` ou `#major` na mensagem do commit de merge
+  para subir minor/major.
+- `versionCode = major*1_000_000 + minor*1_000 + patch` (ex.: `3.0.1` → `3000001`).
+
+## Segredos necessários
+
+Configure em **Settings → Secrets and variables → Actions**:
+
+| Secret | O que é |
+|---|---|
+| `GPG_KEY` | Chave GPG privada (armored) capaz de descriptografar os arquivos do git-secret. |
+| `RELEASE_KEY` | Chave SSH privada de um **deploy key** com acesso de escrita (para o push do bump). |
+
+O deploy key público correspondente deve estar em **Settings → Deploy keys** com "Allow write access".
+
+## Arquivos cifrados com git-secret
+
+Já versionados cifrados (`*.secret`): `jopiter-key.jks`, `keystore.properties`.
+
+**Falta adicionar** o service account da Play Store (JSON baixado do Google Cloud), uma única vez:
+
+```bash
+# com a chave GPG importada no keyring local:
+cp /caminho/para/o/service-account.json fastlane/google-play.json
+git secret add fastlane/google-play.json
+git secret hide
+git add fastlane/google-play.json.secret .gitsecret/paths/mapping.cfg
+git commit -m "Add Play service account to git-secret"
+```
+
+O `keystore.properties` deve conter: `KEYSTORE_PASSWORD`, `KEYSTORE_KEY_ALIAS`, `KEYSTORE_KEY_PASSWORD`.
+Os arquivos descriptografados (`jopiter-key.jks`, `keystore.properties`, `fastlane/google-play.json`)
+são ignorados pelo git (só as versões `.secret` são versionadas).
+
+## Rodar local
+
+```bash
+git secret reveal                       # descriptografa keystore + service account
+./gradlew bundleOfficialRelease         # AAB assinado em app/build/outputs/bundle/officialRelease/
+cd fastlane && bundle install && bundle exec fastlane playstore
+```

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -25,7 +25,7 @@ android {
     applicationId = "app.jopiter"
     targetSdk = 34
     minSdk = 26
-    versionCode = 300
+    versionCode = 3000000
     versionName = "3.0.0"
 
     testApplicationId = "$applicationId.test"
@@ -95,6 +95,7 @@ android {
 
     named("release") {
       isMinifyEnabled = true
+      proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
     }
   }
 }

--- a/app/bump_version.main.kts
+++ b/app/bump_version.main.kts
@@ -1,0 +1,54 @@
+#!/usr/bin/env kotlin
+
+import java.io.File
+
+// Bumps the app version in app/build.gradle.kts, writes the release changelog, commits, tags and
+// pushes. Usage: app/bump_version.main.kts <major|minor|patch> "<changelog>"
+// The commit carries [skip ci] so pushing it does not re-trigger the release workflow.
+
+val buildGradleFile = File("app/build.gradle.kts")
+val changelogsDir = File("fastlane/metadata/android/pt-BR/changelogs")
+val buildGradleContent = buildGradleFile.readText()
+
+val versionCodeRegex = Regex("""versionCode\s*=\s*(\d+)""")
+val versionNameRegex = Regex("""versionName\s*=\s*"([\d.]+)"""")
+
+val currentVersionName = versionNameRegex.find(buildGradleContent)!!.groupValues[1]
+println("Current version: $currentVersionName")
+
+val bumpType = args.getOrNull(0) ?: "patch"
+check(bumpType in listOf("major", "minor", "patch")) { "bump type must be one of: major, minor, patch" }
+
+val versionParts = currentVersionName.split(".").map { it.toIntOrNull() ?: 0 }
+val (newMajor, newMinor, newPatch) = when (bumpType) {
+  "major" -> Triple(versionParts[0] + 1, 0, 0)
+  "minor" -> Triple(versionParts[0], versionParts[1] + 1, 0)
+  else -> Triple(versionParts[0], versionParts[1], versionParts[2] + 1)
+}
+
+val newVersionName = "$newMajor.$newMinor.$newPatch"
+val newVersionCode = newMajor * 1_000_000 + newMinor * 1_000 + newPatch
+println("New version: $newVersionName ($newVersionCode)")
+
+buildGradleFile.writeText(
+  buildGradleContent
+    .replace(versionCodeRegex, "versionCode = $newVersionCode")
+    .replace(versionNameRegex, "versionName = \"$newVersionName\"")
+)
+
+changelogsDir.mkdirs()
+val changelog = (args.getOrNull(1) ?: "Melhorias e correções.").replace("\\n", "\n")
+val changelogFile = File(changelogsDir, "$newVersionCode.txt")
+changelogFile.writeText(changelog)
+println("Wrote changelog to $changelogFile")
+
+fun git(vararg command: String) =
+  ProcessBuilder(listOf("git") + command).inheritIO().start().waitFor()
+
+git("add", buildGradleFile.path, changelogFile.path)
+git("commit", "-m", "🔖 Release $newVersionName ($newVersionCode)", "-m", "[skip ci]")
+git("tag", "-a", newVersionName, "-m", "Release $newVersionName")
+git("push", "origin", "HEAD:main", "--tags")
+
+// Expose the new version to later workflow steps (GitHub release tag/name).
+System.getenv("GITHUB_OUTPUT")?.let { File(it).appendText("version=$newVersionName\n") }

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -1,0 +1,33 @@
+# Jopiter release ProGuard/R8 rules.
+# The app (de)serializes several models with Jackson via reflection, so those classes and the
+# Jackson runtime must be kept from being stripped or renamed.
+
+# Keep metadata needed by Kotlin reflection and Jackson.
+-keepattributes *Annotation*, Signature, InnerClasses, EnclosingMethod
+-keepattributes RuntimeVisibleAnnotations, RuntimeVisibleParameterAnnotations, AnnotationDefault
+-keep class kotlin.Metadata { *; }
+
+# Jackson (databind + kotlin + jsr310 modules) uses reflection heavily.
+-keep class com.fasterxml.jackson.** { *; }
+-keepnames class com.fasterxml.jackson.** { *; }
+-dontwarn com.fasterxml.jackson.**
+-keep class kotlin.reflect.** { *; }
+-dontwarn kotlin.reflect.**
+
+# Jopiter models and DTOs that Jackson binds by field/property name — keep names and members intact.
+-keep class app.jopiter.restaurant.model.** { *; }
+-keep class app.jopiter.subject.external.** { *; }
+
+# Koin (reflection-free, but keep to be safe against R8 stripping module definitions).
+-keep class org.koin.** { *; }
+-dontwarn org.koin.**
+
+# OkHttp / Okio / Fuel — standard library-provided consumer rules plus these suppressions.
+-dontwarn okhttp3.**
+-dontwarn okio.**
+-dontwarn org.conscrypt.**
+-dontwarn org.bouncycastle.**
+-dontwarn org.openjsse.**
+
+# SLF4J (used by Fuel/MockServer transitive deps) — optional at runtime.
+-dontwarn org.slf4j.**

--- a/fastlane/Appfile
+++ b/fastlane/Appfile
@@ -1,0 +1,2 @@
+json_key_file("fastlane/google-play.json")
+package_name("app.jopiter")

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1,0 +1,18 @@
+default_platform(:android)
+
+# Builds and uploads the signed official release bundle to the Play Store. Building the bundle inside
+# the lane (rather than passing an explicit path) lets upload_to_play_store pick it up automatically.
+# Release notes are read from fastlane/metadata/android/<locale>/changelogs/<versionCode>.txt.
+platform :android do
+  desc "Publish the official release bundle to the Play Store production track"
+  lane :playstore do
+    gradle(task: "bundleOfficialRelease")
+    upload_to_play_store(track: "production", timeout: 600)
+  end
+
+  desc "Publish the official release bundle to the Play Store internal test track"
+  lane :internal_test do
+    gradle(task: "bundleOfficialRelease")
+    upload_to_play_store(track: "internal", timeout: 600)
+  end
+end

--- a/fastlane/Gemfile
+++ b/fastlane/Gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+
+gem "fastlane"

--- a/fastlane/metadata/android/pt-BR/changelogs/3000000.txt
+++ b/fastlane/metadata/android/pt-BR/changelogs/3000000.txt
@@ -1,0 +1,1 @@
+Reescrita moderna do Jopiter: restaurante, disciplinas, presença, agenda, notas, importação do JupiterWeb, notificações e tela inicial.


### PR DESCRIPTION
## O que

Prepara o app para publicação **do mesmo jeito que o Petals** publica: **GitHub Actions + git-secret + fastlane**. O Jopiter já tinha `git-secret` configurado (keystore + `keystore.properties` cifrados) e o flavor `official` assinado — faltava a esteira de release.

## Como funciona

`.github/workflows/release.yaml` (gerado de `release.main.kts`, **github-workflows-kt 4.0-SNAPSHOT** + binding server, igual ao Petals) roda **a cada push na `main`**:

1. **Reveal** dos segredos via `git-secret` (`GPG_KEY`).
2. **Bump de versão** semver (`app/bump_version.main.kts`) → reescreve `versionCode`/`versionName`, escreve o changelog pt-BR, commita com `[skip ci]`, cria a tag e dá push (SSH `RELEASE_KEY`).
3. Builda o **APK assinado** e cria um **GitHub Release** com APK + mapping do R8.
4. Builda o **AAB assinado** e publica na **Play Store `production`** via `fastlane`.

Bump: **patch** por padrão; `#minor`/`#major` na mensagem do commit sobem minor/major. `versionCode = major*1_000_000 + minor*1_000 + patch`.

## Segredos a configurar (Settings → Secrets → Actions)

| Secret | O que |
|---|---|
| `GPG_KEY` | Chave GPG privada que descriptografa os arquivos do git-secret |
| `RELEASE_KEY` | Chave SSH (deploy key com escrita) para o push do bump |

## ⚠️ Passo pendente obrigatório

O **service account da Play** ainda **não** está no git-secret. Uma vez:
```bash
cp service-account.json fastlane/google-play.json
git secret add fastlane/google-play.json && git secret hide
git add fastlane/google-play.json.secret .gitsecret/paths/mapping.cfg && git commit -m "Add Play service account"
```
Sem isso, o build/GitHub Release funcionam mas o upload pra Play falha. Detalhes em `RELEASE.md`.

## ⚠️ Comportamento

**Todo merge na `main` publica em produção.** Se os segredos ainda não estiverem configurados, o job falha com segurança no passo de reveal (sem publicar). Para pausar: desabilite o workflow "Release" em Actions, ou troque a faixa para `internal` no `Fastfile`.

## Validação local

- `./gradlew assembleUnofficialRelease` (R8 + proguard) ✅, `detekt` ✅, `spotlessCheck` ✅.
- `release.main.kts` gera o `release.yaml` sem diff (Kotlin 2.4.0) ✅.
- `bump_version.main.kts` testado isolado: `3.0.0 → 3.0.1 (3000001)`, reescreve o gradle e escreve o changelog ✅.
- Assinatura `official` e upload não testáveis localmente (o binário `git-secret` não está instalado nesta máquina) — cobertos pela esteira no CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)