### PR TITLE
Fix flaky HomeViewModelTest

### DIFF
--- a/app/src/test/java/app/jopiter/home/HomeViewModelTest.kt
+++ b/app/src/test/java/app/jopiter/home/HomeViewModelTest.kt
@@ -82,7 +82,9 @@ class HomeViewModelTest : FunSpec({
       )
     )
 
-    val state = viewModel.state.first { it.classes.isNotEmpty() }
+    // Wait for both flows to have emitted their real values: the menu flow starts with a seeded
+    // empty list (so classes are not gated behind the network), which arrives before the menus.
+    val state = viewModel.state.first { it.classes.isNotEmpty() && it.menus.isNotEmpty() }
 
     state.classes.single().subject.name shouldBe "Cálculo"
     state.classes.single().classTime.dayOfWeek shouldBe MONDAY


### PR DESCRIPTION
`HomeViewModel` seeds the menu flow with an empty list (`onStart`) so today's classes render without waiting on the restaurant network fetch. The test awaited only non-empty **classes**, so it could sample the state while **menus** were still the empty seed — flaky. It passed on PR #12 by timing but failed on the release unit-test variant on `main` (`:app:testUnofficialReleaseUnitTest`, `HomeViewModelTest.kt:89`).

Fix: await both `classes` and `menus` before asserting. Verified 3× on the release variant locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)