### PR TITLE
Publish official build under existing Play listing (com.olipsia.jopiter)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -83,6 +83,10 @@ android {
     if (signingConfigs.findByName("production") == null) return@productFlavors
     create("official") {
       dimension = "distribution"
+      // Published to the existing Play Store listing, which was created by the legacy app and keeps
+      // its original (immutable) package name. Only this store build overrides the applicationId; the
+      // code namespace and other variants stay app.jopiter.
+      applicationId = "com.olipsia.jopiter"
       signingConfig = signingConfigs.getByName("production")
     }
   }

--- a/fastlane/Appfile
+++ b/fastlane/Appfile
@@ -1,2 +1,2 @@
 json_key_file("fastlane/google-play.json")
-package_name("app.jopiter")
+package_name("com.olipsia.jopiter")


### PR DESCRIPTION
The Play Store listing for Jopiter was created by the **legacy app** and keeps its original, immutable package name **`com.olipsia.jopiter`**. Probing the Play Developer API with the release service account confirmed it: `app.jopiter` → **404 Package not found**, while `com.olipsia.jopiter` → **OK**.

So the release that failed to upload wasn't a permission problem — the app simply doesn't exist under `app.jopiter`. This overrides the `applicationId` of the **official** (store) flavor and the fastlane `package_name` to `com.olipsia.jopiter`, so releases update the existing listing (with its current users/reviews). The code namespace and the `unofficial`/debug variants stay `app.jopiter`.

Verified locally: `assembleOfficialRelease` builds and the APK's `applicationId` is `com.olipsia.jopiter`.

Merging triggers a Release run that should now upload successfully to production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)