### PR TITLE
fastlane: upload only the AAB to Play (skip_upload_apk)

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -7,12 +7,13 @@ platform :android do
   desc "Publish the official release bundle to the Play Store production track"
   lane :playstore do
     gradle(task: "bundleOfficialRelease")
-    upload_to_play_store(track: "production", timeout: 600)
+    # skip_upload_apk: the workflow also builds an APK (for the GitHub release), so upload only the AAB.
+    upload_to_play_store(track: "production", skip_upload_apk: true, timeout: 600)
   end
 
   desc "Publish the official release bundle to the Play Store internal test track"
   lane :internal_test do
     gradle(task: "bundleOfficialRelease")
-    upload_to_play_store(track: "internal", timeout: 600)
+    upload_to_play_store(track: "internal", skip_upload_apk: true, timeout: 600)
   end
 end


### PR DESCRIPTION
The release workflow builds an APK (for the GitHub release) before the fastlane lane builds the AAB, so `upload_to_play_store` found both and aborted with *"Cannot provide both apk(s) and aab"*. Add `skip_upload_apk: true` so only the bundle is published.

This is the last blocker — the previous run got past authentication and the package lookup (`com.olipsia.jopiter` resolves), failing only on this fastlane input conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)